### PR TITLE
Fix Uruguay profile contact

### DIFF
--- a/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/uy-staatenprofil-uruguay.md
+++ b/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/uy-staatenprofil-uruguay.md
@@ -169,6 +169,6 @@ Dieses Profil basiert auf öffentlich zugänglichen und modellierten Daten. Vert
 
 #### 12.1 Letzter inhaltlich verantwortlicher Ansprechpartner
 Autor: OpenAI Codex
-Kontakt: [noreply@example.com](mailto:noreply@example.com)
+Kontakt: [robert.alexander.massinger@outlook.de](mailto:robert.alexander.massinger@outlook.de)
 Plattform: [GitBook ERDA-Portal](https://app.gitbook.com/o/nt9tg4PqKZ12DXO9pou1/s/vUquUrXlP5zeuZ20Fboy/)
 Letzte Änderung: 2025-06-11

--- a/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/uy-staatenprofil-uruguay.md
+++ b/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/uy-staatenprofil-uruguay.md
@@ -1,8 +1,8 @@
 ---
-description: "State: UY, Date: 2025-06-11, Responsible Author: OpenAI Codex, if from official or institute: Legal Responsible [Author, Institute, Government]: <Behörde/Institut>"
+description: "State: UY, Date: 2025-06-11, Responsible Author: Robert Alexander Massinger, if from official or institute: Legal Responsible [Author, Institute, Government]: <Behörde/Institut>"
 country: "UY"
 date: "2025-06-11"
-author: "OpenAI Codex"
+author: "Robert Alexander Massinger"
 legal_responsible: "<Behörde/Institut>"
 layout: "ERDA-State-Profile-v4"
 version: "1.0"
@@ -168,7 +168,7 @@ Uruguay ist eine stabile, wohlhabende Demokratie in Südamerika. Mit gut ausgeba
 Dieses Profil basiert auf öffentlich zugänglichen und modellierten Daten. Vertreter:innen der Republik Uruguay sowie interessierte Fachstellen sind herzlich eingeladen, eigene Perspektiven, Ergänzungen und Aktualisierungen beizutragen – für ein gemeinsames Bild einer resilienten und demokratischen Zukunft Europas.
 
 #### 12.1 Letzter inhaltlich verantwortlicher Ansprechpartner
-Autor: OpenAI Codex
+Autor: Robert Alexander Massinger
 Kontakt: [robert.alexander.massinger@outlook.de](mailto:robert.alexander.massinger@outlook.de)
 Plattform: [GitBook ERDA-Portal](https://app.gitbook.com/o/nt9tg4PqKZ12DXO9pou1/s/vUquUrXlP5zeuZ20Fboy/)
 Letzte Änderung: 2025-06-11


### PR DESCRIPTION
## Summary
- replace email placeholder in Uruguay profile

## Testing
- `python scripts/gitbook_worker.py --help | head -n 20` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684aa9ba0b6c832a97311f934de5c7f7