### PR TITLE
Normalisiere ERDA-Status in Staatenprofilen

### DIFF
--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/at-staatenprofil-osterreich.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/at-staatenprofil-osterreich.md
@@ -20,7 +20,7 @@ version: "1.0"
 * **Geografische Lage (Kontinent, Region):** Mitteleuropa, Binnenstaat; grenzt an Deutschland, Tschechien, Slowakei, Ungarn, Slowenien, Italien, Schweiz, Liechtenstein
 * **Bevölkerung (Stand 2025):** 9 113 574
 * **Regierungsform & Verfassungsstatus (Stand 2025):** Föderale parlamentarische Republik, Bundesverfassung 1920 (rev. 1929, 1958, 2000)
-* **ERDA-Status:** Mitglied
+* 📅 ERDA-Status: Mitglied
 * **Zukünftige Rolle im ERDA-Netzwerk:** Bildungsnation & Kulturvermittler
 ***
 

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/be-staatenprofil-belgien.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/be-staatenprofil-belgien.md
@@ -22,7 +22,7 @@ version: "1.0"
 * **Regierungsform & Verfassungsstatus:**\
   Föderale parlamentarische konstitutionelle Monarchie (Verfassung von 1831)\
   Details: [Belgium.be](https://www.belgium.be/de/ueber_belgien/staat/federale_staat)
-* **ERDA-Status:** Vollmitglied
+* 📅 ERDA-Status: Mitglied
 * **Rolle im ERDA-Netzwerk (Zukunft):** Cyberhub & Kulturvermittler\
   (Quelle: interne ERDA-Projektdokumentation)
 

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/bg-staatenprofil-bulgarien.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/bg-staatenprofil-bulgarien.md
@@ -16,7 +16,7 @@ version: "1.0"
 * Geografische Lage (Kontinent, Region): Südosteuropa, Balkan, Schwarzmeerküste
 * Bevölkerung (Stand 2025): ca. 6,45 Mio. (World Bank 2023)
 * Regierungsform & Verfassungsstatus (Stand 2025): Parlamentarische Republik, EU- und NATO-Mitglied
-* ERDA-Status [assoziiert | Mitglied | Beitrittskandidat | souveräner Partner]: Mitglied
+* 📅 ERDA-Status: Mitglied
 * Zukünftige Rolle im ERDA-Netzwerk: Brückenknoten Balkan-Schwarzmeer, Digitalisierungsdrehscheibe
 
 ## 2. Demografie & Gesellschaft

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/cz-staatenprofil-tschechien.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/cz-staatenprofil-tschechien.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 📺 Geografische Lage: Mitteleuropa, Nachbarstaaten: Deutschland, Polen, Österreich, Slowakei
 * 👥 Bevölkerung (2025): ca. 10,5 Mio.
 * 🧠 Regierungsform & Verfassungsstatus (2025): Parlamentarische Demokratie, Verfassungsbindung: Ja
-* 🗓️ ERDA-Status: Mitglied
+* 📅 ERDA-Status: Mitglied
 * 🗺️ Rolle im ERDA-Netzwerk (Zukunft): Kulturvermittler, Tech-Transfer-Region, Bildungsbrücke zu Ost- und Mitteleuropa
 
 ***

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/dk-staatenprofil-danemark.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/dk-staatenprofil-danemark.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗺️ **Geografische Lage:** Nordeuropa, Skandinavien, zwischen Nordsee und Ostsee
 * 👥 **Bevölkerung (2025):** ca. 5,98 Mio.
 * 🧠 **Regierungsform & Verfassungsstatus (2025):** Unitarische parlamentarische konstitutionelle Monarchie, Verfassungsbindung: Ja
-* 📅 **ERDA-Status:** Mitglied
+* 📅 ERDA-Status: Mitglied
 * 🧭 **Rolle im ERDA-Netzwerk (Zukunft):** Arktisknoten (via Grönland), Innovations- und Nachhaltigkeitsexporteur
 
 ***

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/ee-staatenprofil-republik-estland.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/ee-staatenprofil-republik-estland.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗺️ **Geografische Lage:** Nordeuropa, südlich von Finnland am Finnischen Meerbusen; grenzt im Süden an Lettland, im Osten an Russland; Küstenlänge 3 794 km ([Wikipedia](https://en.wikipedia.org/wiki/Estonia))
 * 👥 **Bevölkerung (2025):** 1 369 285 ([Statistik Estonia](https://stat.ee/en/find-statistics/statistics-theme/population))
 * 🧠 **Regierungsform & Verfassungsstatus (2025):** Unitary parlamentarische Republik; Verfassung von 1992 ([Riigikogu](https://www.riigikogu.ee/en/constitution-of-the-republic-of-estonia/))
-* 📅 **ERDA-Status:** Mitglied
+* 📅 ERDA-Status: Mitglied
 * 🧭 **Rolle im ERDA-Netzwerk (Zukunft):** Digitalnation & Cyberhub
 
 ***

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/es-staatenprofil-spanien.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/es-staatenprofil-spanien.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗘️ **Geografische Lage:** Südwest-Europa, Iberische Halbinsel
 * 👥 **Bevölkerung (2025):** 47 889 958 Einw.
 * 🧠 **Regierungsform & Verfassungsstatus (2025):** Parlamentarische konstitutionelle Monarchie (Verfassungsbindung: Ja)
-* 🗓️ **ERDA-Status:** Mitglied
+* 📅 ERDA-Status: Mitglied
 * 🗭 **Rolle im ERDA-Netzwerk (Zukunft):** Kulturvermittler, Green-Tech-Hub, Tourismus-& Innovationspartner
 
 ***

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/fi-staatenprofil-finnland.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/fi-staatenprofil-finnland.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗺️ **Geografische Lage:** Nordeuropa, Grenzstaat im Nordischen Raum (Schweden, Norwegen, Russland; Ostsee im Süden)
 * 👥 **Bevölkerung (2025):** 5.675.983 (geschätzt zum 1. Januar 2025) citeturn3search8
 * 🧠 **Regierungsform & Verfassungsstatus (2025):** Parlamentarische Republik, Verfassungsgebunden (1919)
-* 📅 **ERDA-Status:** Mitglied
+* 📅 ERDA-Status: Mitglied
 * 🧭 **Rolle im ERDA-Netzwerk (Zukunft):** Arktisknoten, Bildungsnation & Nachhaltigkeitspionier
 
 ***

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/fr-staatenprofil-frankreich.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/fr-staatenprofil-frankreich.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗺️ **Geografische Lage:** Westeuropa (Metropolitain), plus fünf Übersee­regionen (Guayana, Guadeloupe, Martinique, Réunion, Mayotte) und zahlreiche Territorien weltweit
 * 👥 **Bevölkerung (1. Jan. 2025):** 68.606.000 (Einwohner:innen)
 * 🧠 **Regierungsform & Verfassungsstatus (2025):** Semi-präsidiale Republik, Verfassungsbindung: Ja
-* 📅 **ERDA-Status:** Mitglied
+* 📅 ERDA-Status: Mitglied
 * 🧭 **Rolle im ERDA-Netzwerk (Zukunft):** Kulturvermittler, Raumfahrt- & Energiepartner, Kernstaat der Verteidigungsarchitektur
 
 ***

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/ie-staatenprofil-republik-irland.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/ie-staatenprofil-republik-irland.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗺️ **Geografische Lage:** Nordwest-Europa, Insel Irland, Zugang zum Atlantik (Küste 1 448 km) ([CIA Factbook](https://www.cia.gov/the-world-factbook/countries/ireland/))
 * 👥 **Bevölkerung (2025):** 5 308 039 ([Worldometers](https://www.worldometers.info/world-population/ireland-population/))
 * 🧠 **Regierungsform & Verfassungsstatus (2025):** Unitary parliamentary republic, Verfassung von 1937 ([Gov.ie](https://www.gov.ie/departments/department-of-public-expenditure-and-reform/))
-* 📅 **ERDA-Status:** Mitglied
+* 📅 ERDA-Status: Mitglied
 * 🧭 **Rolle im ERDA-Netzwerk (Zukunft):** Bildungs- und Digitalisierungsnation, Cyberhub
 
 ***

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/it-staatenprofil-italien.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/it-staatenprofil-italien.md
@@ -18,7 +18,7 @@ version: "1.0"
 * **Geografische Lage:** Südeuropa, italienische Halbinsel im Mittelmeer
 * **Bevölkerung (2025):** ca. 58,93 Mio.
 * **Regierungsform & Verfassungsstatus (2025):** Parlamentarische Republik, Verfassung 1948 (Verfassungsbindung: Ja)
-* **ERDA-Status:** Mitglied
+* 📅 ERDA-Status: Mitglied
 * **Rolle im ERDA-Netzwerk (Zukunft):** Kulturvermittler, Tourismus-Hub, Nahrungsmittel- & Luxusgüter-Expertise
 
 ***

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/lt-staatenprofil-republik-litauen.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/lt-staatenprofil-republik-litauen.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗺️ **Geografische Lage:** Nordeuropa, Ostseestaat, Grenze zu Lettland, Belarus, Polen, Russland (Kaliningrad) ([CIA Factbook](https://www.cia.gov/the-world-factbook/countries/lithuania/))
 * 👥 **Bevölkerung (2025):** 2 830 144 ([Worldometer](https://www.worldometers.info/world-population/lithuania-population/)) citeturn7search1
 * 🧠 **Regierungsform & Verfassungsstatus (2025):** Parlamentarische Republik, Verfassung von 1992 ([Seimas](https://www.lrs.lt/sip/portal.show?p_r=8804))
-* 📅 **ERDA-Status:** Mitglied
+* 📅 ERDA-Status: Mitglied
 * 🧭 **Rolle im ERDA-Netzwerk (Zukunft):** Digitalisierungs- und Innovationshub, Brückenbauer an Rand der EU
 
 ***

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/lv-staatenprofil-republik-lettland.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/lv-staatenprofil-republik-lettland.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗺️ **Geografische Lage:** Nördliches Baltikum, grenzt an Estland, Russland, Belarus, Litauen; Ostseeküste 494 km ([CIA Factbook](https://www.cia.gov/the-world-factbook/countries/latvia/))
 * 👥 **Bevölkerung (2025):** 1 855 000 (Schätzung; 1 Juni 2024: 1 861 900) ([Demographics of Latvia, Wikipedia](https://en.wikipedia.org/wiki/Demographics_of_Latvia))
 * 🧠 **Regierungsform & Verfassungsstatus (2025):** Parlamentarische Republik, Verfassung von 1922 (rev. regelmäßig) ([Saeima](https://www.saeima.lv/))
-* 📅 **ERDA-Status:** Mitglied
+* 📅 ERDA-Status: Mitglied
 * 🧭 **Rolle im ERDA-Netzwerk (Zukunft):** Cyberhub & Digitales Transformationszentrum
 
 ***

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/nl-staatenprofil-niederlande.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/nl-staatenprofil-niederlande.md
@@ -17,7 +17,7 @@ version: "1.0"
 * 🗺️ **Geografische Lage:** Westeuropa, Küstenstaat an Nordsee, grenzt an Deutschland und Belgien
 * 👥 **Bevölkerung (2025):** 18.327.400
 * 🧠 **Regierungsform & Verfassungsstatus (2025):** Konstitutionelle Monarchie, parlamentarische Demokratie (Verfassungsbindung: Ja)
-* 📅 **ERDA-Status:** Mitglied
+* 📅 ERDA-Status: Mitglied
 * 🧭 **Rolle im ERDA-Netzwerk (Zukunft):** Logistik- und Innovationshub, Wasser- und Küstermanagement-Expertise, digitaler Cyberhub
 
 ***

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/pt-staatenprofil-republik-portugal.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/pt-staatenprofil-republik-portugal.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗺️ **Geografische Lage:** Südwesteuropa, Iberische Halbinsel, Grenze Spanien im Osten und Norden, Atlantikküste im Westen und Süden ([CIA Factbook](https://www.cia.gov/the-world-factbook/countries/portugal/))
 * 👥 **Bevölkerung (2025):** 10 300 000 (geschätzt) ([Worldometers](https://www.worldometers.info/world-population/portugal-population/))
 * 🧠 **Regierungsform & Verfassungsstatus (2025):** Unitarische parlamentarische Republik, Verfassung von 1976 ([Verfassung von Portugal](https://www.portugal.gov.pt/pt/gc21/area-de-governo/justica/conteudos/constitui%C3%A7%C3%A3o-da-rep%C3%BAblica-portuguesa))
-* 📅 **ERDA-Status:** Mitglied
+* 📅 ERDA-Status: Mitglied
 * 🧭 **Rolle im ERDA-Netzwerk (Zukunft):** Maritime Gateway & Renewable Energy Hub
 
 ***

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/ro-staatenprofil-rumanien.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/ro-staatenprofil-rumanien.md
@@ -18,7 +18,7 @@ version: "1.0"
 * \ud83d\uddfa\ufe0f Geografische Lage: S\u00fcdosteuropa, Grenzstaat am Schwarzen Meer, grenzt an Bulgarien, Serbien, Ungarn, Moldau und die Ukraine
 * \ud83d\udc65 Bev\u00f6lkerung (2025): ca. 19 Mio. (World Bank 2023)
 * \ud83e\uddee Regierungsform & Verfassungsstatus (2025): Semipr\u00e4sidentielle Republik, Mitglied der EU und NATO
-* \ud83d\udcc5 ERDA-Status: Mitglied
+* 📅 ERDA-Status: Mitglied
 * \ud83d\udd2c Rolle im ERDA-Netzwerk (Zukunft): Schwarzmeer-Br\u00fcckenstaat, IT- und Ingenieurshub, Landwirtschafts- und Energiepotenzial
 
 ***

--- a/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/staatenprofil-deutschland-de.md
+++ b/anhang-b-erda-staatenprofile/3.-staatenprofile-eu-erda-kernlander/staatenprofil-deutschland-de.md
@@ -19,7 +19,7 @@ version: "1.0"
 * 🗺️ **Geografische Lage:** Mitteleuropa
 * 👥 **Bevölkerung (2025):** ca. 83,5 Mio. Einw. ([Destatis – Bevölkerungsstand](https://www.destatis.de/DE/Themen/Gesellschaft-Umwelt/Bevoelkerung/Bevoelkerungsstand/_inhalt.html))
 * 🧠 **Regierungsform & Verfassungsstatus (2025):** Parlamentarische Demokratie, Grundgesetz (Verfassungsbindung: Ja)
-* 📅 **ERDA-Status:** Mitglied
+* 📅 ERDA-Status: Mitglied
 * 🧭 **Rolle im ERDA-Netzwerk (Zukunft):** Innovationsmotor, Cyberhub, Verteidigungsdrehkreuz, Bildungsexporteur
 
 ***

--- a/anhang-b-erda-staatenprofile/4.-staatenprofile-eu-erda-erweiterte-partnerschaft/ua-staatenprofil-ukraine.md
+++ b/anhang-b-erda-staatenprofile/4.-staatenprofile-eu-erda-erweiterte-partnerschaft/ua-staatenprofil-ukraine.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗺️ **Geografische Lage:** Osteuropa; Nachbarn: Polen, Slowakei, Ungarn, Rumänien, Moldau, Belarus, Russland
 * 👥 **Bevölkerung (2025):** ca. 37 Mio.
 * 🧠 **Regierungsform & Verfassungsstatus (2025):** Semipräsidiale Republik, Verfassung von 1996; territoriale Integrität bis Ende 2025 wiederhergestellt
-* 📅 **ERDA-Status:** Souveräner Partner, Beitrittskandidat
+* 📅 ERDA-Status: Souveräner Partner, Beitrittskandidat
 * 🧭 **Zukünftige Rolle im ERDA-Netzwerk:** Sicherheitsanker an der Ostflanke, landwirtschaftlicher und technologischer Hub
 
 ***

--- a/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/au-staatenprofil-australien.md
+++ b/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/au-staatenprofil-australien.md
@@ -18,7 +18,7 @@ version: "1.0"
 * **Geografische Lage (Kontinent, Region):** Ozeanien; Inselkontinent zwischen Indischem und Pazifischem Ozean
 * **Bevölkerung (Stand 2023):** 26 658 948^[World Bank, 2023]
 * **Regierungsform & Verfassungsstatus (Stand 2025):** Föderale parlamentarische Monarchie im Commonwealth
-* **ERDA-Status:** Globale/r Assoziierter
+* 📅 ERDA-Status: Globale/r Assoziierter
 * **Zukünftige Rolle im ERDA-Netzwerk:** Indo-Pazifik-Partner und Technologiekooperation
 
 ### 2. Demografie & Gesellschaft

--- a/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/ca-staatenprofil-kanada.md
+++ b/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/ca-staatenprofil-kanada.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗺️ Geografische Lage: Nordamerika; grenzt an die USA, den Atlantik, den Pazifik und die Arktis
 * 👥 Bevölkerung (2023): 40,1 Mio.[^wb-pop]
 * 🧠 Regierungsform & Verfassungsstatus (2025): Föderale parlamentarische Demokratie, konstitutionelle Monarchie
-* 📅 ERDA-Status: Global assoziiert
+* 📅 ERDA-Status: Globale/r Assoziierter
 * 🧭 Rolle im ERDA-Netzwerk (Zukunft): Arktisknoten und Rohstoff‑/Innovationspartner (hypothetisch: ERDA Scenario Modeling Report 2025)
 
 ***

--- a/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/cl-staatenprofil-chile.md
+++ b/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/cl-staatenprofil-chile.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗺️ Geografische Lage: Südamerika, Pazifikküste; grenzt an Peru, Bolivien und Argentinien
 * 👥 Bevölkerung (2025): ca. 20 Mio.*
 * 🧑‍⚖️ Regierungsform & Verfassungsstatus (2025): Präsidiale Republik
-* 📅 ERDA-Status: Globaler Assoziierter
+* 📅 ERDA-Status: Globale/r Assoziierter
 * 🧭 Rolle im ERDA-Netzwerk (Zukunft): Rohstoffpartner (Kupfer, Lithium), Pazifik-Brückenstaat
 
 ***

--- a/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/cr-staatenprofil-costa-rica.md
+++ b/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/cr-staatenprofil-costa-rica.md
@@ -18,7 +18,7 @@ version: "1.0"
 * **Geografische Lage (Kontinent, Region):** Mittelamerika; zwischen Nicaragua und Panama
 * **Bevölkerung (Stand 2025):** ca. 5,2 Mio.^[World Bank, 2023]
 * **Regierungsform & Verfassungsstatus (Stand 2025):** Präsidentielle Republik
-* **ERDA-Status:** Globale/r Assoziierter
+* 📅 ERDA-Status: Globale/r Assoziierter
 * **Zukünftige Rolle im ERDA-Netzwerk:** Vermittler nachhaltiger Tourismus und Umweltinnovation
 
 ### 2. Demografie & Gesellschaft

--- a/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/in-staatenprofil-indien.md
+++ b/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/in-staatenprofil-indien.md
@@ -16,7 +16,7 @@ version: "1.0"
 * Geografische Lage (Kontinent, Region): Südasien; grenzt u.a. an Pakistan, China, Nepal und Bangladesch
 * Bevölkerung (Stand 2025): ca. 1,46 Mrd. (UN World Population Prospects 2022)
 * Regierungsform & Verfassungsstatus (Stand 2025): Parlamentarische Bundesrepublik
-* ERDA-Status [assoziiert | Mitglied | Beitrittskandidat | souveräner Partner]: assoziiert
+* 📅 ERDA-Status: Assoziiert
 * Zukünftige Rolle im ERDA-Netzwerk: Digital-Hub & Entwicklungspartner in Asien
 
 ## 2. Demografie & Gesellschaft

--- a/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/jp-staatenprofil-japan.md
+++ b/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/jp-staatenprofil-japan.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗺️ Geografische Lage: Inselstaat in Ostasien, nordwestlicher Pazifik
 * 👥 Bevölkerung (2023): ca. 124,5 Mio.[1]
 * 🧬 Regierungsform & Verfassungsstatus (2025): Konstitutionelle Monarchie mit parlamentarischer Regierung
-* 📅 ERDA-Status: Globale Assoziierte
+* 📅 ERDA-Status: Globale/r Assoziierter
 * 🔎 Rolle im ERDA-Netzwerk (Zukunft): High-Tech-Drehscheibe und Indo-Pazifik-Partner
 
 ***

--- a/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/kr-staatenprofil-sued-korea.md
+++ b/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/kr-staatenprofil-sued-korea.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗺️ Geografische Lage: Ostasien, südlicher Teil der koreanischen Halbinsel
 * 👥 Bevölkerung (2025): ca. 51,8 Mio. (World Bank 2023)
 * 🧠 Regierungsform & Verfassungsstatus (2025): Präsidialrepublik
-* 📅 ERDA-Status: assoziiert
+* 📅 ERDA-Status: Assoziiert
 * 🧭 Rolle im ERDA-Netzwerk (Zukunft): Technologieknoten und Brücke zwischen Ostasien und Europa
 
 ***

--- a/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/na-staatenprofil-namibia.md
+++ b/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/na-staatenprofil-namibia.md
@@ -18,7 +18,7 @@ version: "1.0"
 * **Geografische Lage (Kontinent, Region):** Südwestafrika, Atlantikküste; grenzt an Angola, Sambia, Botswana und Südafrika
 * **Bevölkerung (Stand 2023):** 2,96 Mio.[^wb-pop]
 * **Regierungsform & Verfassungsstatus (Stand 2025):** Präsidiale Republik, Verfassung von 1990
-* **ERDA-Status:** Globale/r Assoziierter
+* 📅 ERDA-Status: Globale/r Assoziierter
 * **Zukünftige Rolle im ERDA-Netzwerk:** Partner für erneuerbare Energie und Hafenlogistik (Walvis Bay)
 
 ### 2. Demografie & Gesellschaft

--- a/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/sn-staatenprofil-senegal.md
+++ b/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/sn-staatenprofil-senegal.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗺️ Geografische Lage: Westafrika; grenzt an Mauretanien, Mali, Guinea, Guinea-Bissau und Gambia, Atlantikküste
 * 👥 Bevölkerung (2023): 18,1 Mio.[^wb-pop]
 * 🧠 Regierungsform & Verfassungsstatus (2025): Semipräsidentielle Republik
-* 📅 ERDA-Status: Global assoziiert
+* 📅 ERDA-Status: Globale/r Assoziierter
 * 🧭 Rolle im ERDA-Netzwerk (Zukunft): Brückenknoten Westafrika, erneuerbare Energiepartnerschaften (hypothetisch: ERDA Scenario Modeling Report 2025)
 
 ***

--- a/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/tn-staatenprofil-tunesien.md
+++ b/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/tn-staatenprofil-tunesien.md
@@ -18,7 +18,7 @@ version: "1.0"
 * **Geografische Lage (Kontinent, Region):** Nordafrika, Mittelmeerküste
 * **Bevölkerung (Stand 2023):** 12 200 431^[World Bank, 2023]
 * **Regierungsform & Verfassungsstatus (Stand 2025):** Präsidentiale Republik (Verfassung 2022)
-* **ERDA-Status:** Globale/r Assoziierter
+* 📅 ERDA-Status: Globale/r Assoziierter
 * **Zukünftige Rolle im ERDA-Netzwerk:** Solarenergie-Hub und Brückenstaat Nordafrika (hypothetisch: ERDA Scenario Modeling Report 2025)
 
 ### 2. Demografie & Gesellschaft

--- a/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/tw-staatenprofil-taiwan.md
+++ b/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/tw-staatenprofil-taiwan.md
@@ -18,7 +18,7 @@ version: "1.0"
 * 🗺️ Geografische Lage: Ostasien, Insel im Westpazifik vor der Küste des chinesischen Festlands
 * 👥 Bevölkerung (2025): ca. 23,3 Mio.\* [^1]
 * 🧑‍⚖️ Regierungsform & Verfassungsstatus (2025): Semipräsidentielle Demokratie
-* 📅 ERDA-Status: Globaler Assoziierter
+* 📅 ERDA-Status: Globale/r Assoziierter
 * 🧭 Rolle im ERDA-Netzwerk (Zukunft): Technologie- und Innovationsdrehscheibe
 
 ***

--- a/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/uy-staatenprofil-uruguay.md
+++ b/anhang-b-erda-staatenprofile/5.-staatenprofile-erda-globale-assoziierte/uy-staatenprofil-uruguay.md
@@ -18,7 +18,7 @@ version: "1.0"
 * **Geografische Lage (Kontinent, Region):** Südamerika, La-Plata-Region zwischen Brasilien und Argentinien
 * **Bevölkerung (Stand 2023):** ca. 3,39 Mio.^[World Bank, 2023](https://api.worldbank.org/v2/country/URY/indicator/SP.POP.TOTL)
 * **Regierungsform & Verfassungsstatus (Stand 2025):** Präsidiale Republik mit Mehrparteiensystem
-* **ERDA-Status:** Globale/r Assoziierter
+* 📅 ERDA-Status: Globale/r Assoziierter
 * **Zukünftige Rolle im ERDA-Netzwerk:** Digitaler Brückenstaat Mercosur-EU, Agrar- und Nachhaltigkeitspartner
 
 ### 2. Demografie & Gesellschaft


### PR DESCRIPTION
## Summary
- angleichen der Formulierung der *ERDA-Status*-Zeile in allen Staatenprofilen
- Korrektur von Schreibvarianten wie `Vollmitglied`, `assoziiert` oder unterschiedlichen Begriffen für globale Partner

## Testing
- `python3 tools/check_staatenprofil_links.py --help`

------
https://chatgpt.com/codex/tasks/task_e_684b1799276c832aafeeff2ffc3d5873