### PR TITLE
Fix external reference update logic

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/__init__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__init__.py
@@ -1107,8 +1107,8 @@ def proof_and_repair_external_references(
                         file,
                         repaired_reference["error"],
                     )
-            # write back the result to the file
-            with open(file, "a", encoding="utf-8") as wf:
+            # write back the result to the file, replacing previous content
+            with open(file, "w", encoding="utf-8") as wf:
                 wf.writelines(lines)
     return report
 

--- a/tools/gitbook_worker/tests/test_external_repair.py
+++ b/tools/gitbook_worker/tests/test_external_repair.py
@@ -1,0 +1,23 @@
+import gitbook_worker
+
+
+def test_proof_and_repair_replaces_content(tmp_path, monkeypatch):
+    md = tmp_path / "test.md"
+    original_lines = ["# Title\n", "\n", "## Quellen\n", "1. Example https://example.com\n"]
+    md.write_text("".join(original_lines))
+
+    def fake_extract(file):
+        return {str(file): [{"Example": {"lineno": 4, "line": "1. Example https://example.com", "numbering": "1", "level": 2}}]}
+
+    def fake_proof(**kwargs):
+        return True, {"success": True, "new": "1. Example NEW", "validation_date": "2024-01-01", "type": "external reference", "hint": None}
+
+    monkeypatch.setattr(gitbook_worker, "extract_sources_of_a_md_file_to_dict", fake_extract)
+    monkeypatch.setattr(gitbook_worker, "proof_and_repair_external_reference", fake_proof)
+
+    gitbook_worker.proof_and_repair_external_references([str(md)], "", "", "", "")
+
+    content = md.read_text().splitlines()
+    assert content.count("1. Example NEW") == 1
+    assert "1. Example https://example.com" not in content
+


### PR DESCRIPTION
## Summary
- ensure `proof_and_repair_external_references` rewrites files
- add regression test for duplicate-free overwrite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c105971c8832aac6bef4c0bdd0545