### PR TITLE
Add language aware sources header pattern

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/__init__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__init__.py
@@ -135,6 +135,26 @@ def extract_multiline_list_items(text):
     return pattern.findall(text)
 
 
+def get_language_dependent_header_pattern_for_sources(language: str = "de") -> re.Pattern:
+    """Return a regex to match source section headers.
+
+    The pattern is language-aware and currently supports German and English
+    headings. Unknown languages fall back to a generic pattern that matches
+    both variants.
+    """
+    lang = (language or "").lower()
+    patterns = {
+        "de": ["Quellen", "Quellen & Verweise", "Quellen und Verweise"],
+        "en": ["Sources", "References", "Sources & References"],
+    }
+    words = patterns.get(lang, []) + patterns["de"] + patterns["en"]
+    # Deduplicate while preserving order
+    seen = set()
+    words = [w for w in words if not (w in seen or seen.add(w))]
+    regex = "|".join(re.escape(w) for w in words)
+    return re.compile(rf"^(#{{1,6}})\s*(?:{regex})", re.IGNORECASE)
+
+
 def extract_sources_of_a_md_file_to_dict(
     md_file,
 ) -> Dict[
@@ -142,8 +162,7 @@ def extract_sources_of_a_md_file_to_dict(
 ]:  # returns a dict {str(md_file): [{name: {numbering, link, comment, line, kind}}]}
     """Extract 'Sources' sections from markdown files into a dict.<br>
     Typically references, sources or bibliography sections.<br>
-    TODO: get_language_dependent_header_pattern_for_sources()<br>
-    1. Current Header Pattern: ^.* Quellen<br>
+    Uses get_language_dependent_header_pattern_for_sources()<br>
     2. Current List Pattern: see get_extract_multiline_list_items_pattern()<br>
     <br>
     Dict Format:<br>
@@ -187,7 +206,7 @@ def extract_sources_of_a_md_file_to_dict(
     Returns a dictionary of sources found in the markdown files.
     """
     sources = {}
-    header_pattern = re.compile(r"^(#{1,6})\s*.*Quellen", re.IGNORECASE)
+    header_pattern = get_language_dependent_header_pattern_for_sources()
     list_pattern = get_extract_multiline_list_items_pattern()
     if md_file:
         try:
@@ -248,8 +267,7 @@ def extract_sources_of_a_md_file_to_dict(
 def extract_sources_to_dict(md_files) -> Dict[str, List[Dict[str, Dict[str, Any]]]]:
     """Extract 'Sources' sections from markdown files into a dict.<br>
     Typically references, sources or bibliography sections.<br>
-    TODO: get_language_dependent_header_pattern_for_sources()<br>
-    1. Current Header Pattern: ^.* Quellen<br>
+    Uses get_language_dependent_header_pattern_for_sources()<br>
     2. Current List Pattern: ^\s*([0-9a-z\*]+[\.) ]|[-*+])\s+<br>
     Shall find all lines starting with<br>
         a number followed by a dash or bracket or whitespace and then text<br>

--- a/tools/gitbook_worker/tests/test_sources.py
+++ b/tools/gitbook_worker/tests/test_sources.py
@@ -1,0 +1,14 @@
+import gitbook_worker
+
+
+def test_header_pattern_matches_multiple_languages():
+    pattern = gitbook_worker.get_language_dependent_header_pattern_for_sources()
+    assert pattern.match("## Quellen")
+    assert pattern.match("## Sources")
+
+
+def test_extract_sources_with_english_header(tmp_path):
+    md = tmp_path / "test.md"
+    md.write_text("# T\n\n## Sources\n1. Example https://example.com\n")
+    result = gitbook_worker.extract_sources_of_a_md_file_to_dict(str(md))
+    assert result[str(md)]


### PR DESCRIPTION
## Summary
- add a helper `get_language_dependent_header_pattern_for_sources`
- use the helper to detect source sections
- test the new helper and english source headers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c12594570832a8669a3fa203718ca