### PR TITLE
Add unit tests for core markdown utilities

### DIFF
--- a/tools/gitbook_worker/tests/test_core_functions.py
+++ b/tools/gitbook_worker/tests/test_core_functions.py
@@ -1,0 +1,64 @@
+import os
+import gitbook_worker
+
+class FakeResponse:
+    def __init__(self, status=200, reason="OK"):
+        self.status_code = status
+        self.reason = reason
+
+def test_parse_summary_multi_level(tmp_path):
+    nested = tmp_path / "dir" / "sub"
+    nested.mkdir(parents=True)
+    md1 = tmp_path / "root.md"
+    md2 = nested / "child.md"
+    md1.write_text("Root")
+    md2.write_text("Child")
+    summary = tmp_path / "SUMMARY.md"
+    summary.write_text("* [R](root.md)\n  * [C](dir/sub/child.md)\n")
+    files = gitbook_worker.parse_summary(str(summary))
+    assert files == [str(md1), str(md2)]
+
+def test_extract_multiline_list_items_various():
+    text = "1. One\n  continued\n2) Two\n* Bullet\n  extra line"
+    result = gitbook_worker.extract_multiline_list_items(text)
+    assert result == ["1. One\n  continued", "2) Two", "* Bullet\n  extra line"]
+
+def test_validate_metadata_mixed_files(tmp_path):
+    good = tmp_path / "good.md"
+    bad = tmp_path / "bad.md"
+    good.write_text("---\ntitle: T\nauthor: A\ndate: 2020\n---\n")
+    bad.write_text("---\ntitle: T\n---\n")
+    issues = gitbook_worker.validate_metadata([str(good), str(bad)])
+    assert (str(bad), "Missing metadata field: author") in issues
+    assert not any(i[0] == str(good) for i in issues)
+
+def test_check_duplicate_headings_across_files(tmp_path):
+    a = tmp_path / "a.md"
+    b = tmp_path / "b.md"
+    a.write_text("# Heading\n")
+    b.write_text("## Heading\n")
+    dups = gitbook_worker.check_duplicate_headings([str(a), str(b)])
+    assert dups == [(str(b), 1, "heading", f"{a}:1")]
+
+def test_list_todos_simple(tmp_path):
+    md = tmp_path / "todo.md"
+    md.write_text("Do\nTODO item\ntext\nFIXME note")
+    todos = gitbook_worker.list_todos([str(md)])
+    assert [t[1] for t in todos] == [2, 4]
+
+def test_check_images_local_and_remote(tmp_path, monkeypatch):
+    img = tmp_path / "ok.png"
+    img.write_text("data")
+    md = tmp_path / "file.md"
+    md.write_text(
+        f"![]({img.name})\n![](missing.png)\n![](http://good/img)\n![](http://bad/img)"
+    )
+    def fake_head(url, timeout=5):
+        return FakeResponse(200) if "good" in url else FakeResponse(404, "Not Found")
+    monkeypatch.setattr(gitbook_worker.requests, "head", fake_head)
+    missing = gitbook_worker.check_images([str(md)])
+    paths = [m[2] for m in missing]
+    assert os.path.join(str(tmp_path), "missing.png") in paths
+    assert "http://bad/img" in paths
+    assert "http://good/img" not in paths
+    assert os.path.join(str(tmp_path), "ok.png") not in paths


### PR DESCRIPTION
## Summary
- test `parse_summary` across nested folders
- test parsing of multiline lists
- validate metadata frontmatter parsing
- detect duplicate headings
- collect TODO markers
- verify handling of local and remote images with mocked network

## Testing
- `pytest tools/gitbook_worker/tests --cov=gitbook_worker --cov-config=.coveragerc -q`

------
https://chatgpt.com/codex/tasks/task_e_684c32307bf8832aa7f98c10edf8d0f4