### PR TITLE
Remove unused imports from gitbook_worker

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/__init__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__init__.py
@@ -1,21 +1,16 @@
 import ast
-import io
 import random
 import time
 from typing import List
-from enum import Enum
 import stat
 import subprocess
 import sys
 import os
 import re
-import argparse
 import csv
 from typing import Any, Dict
 import requests
 import logging
-from datetime import datetime
-import requests
 import json
 import shutil
 
@@ -30,7 +25,6 @@ except ImportError:
 
 try:
     import textstat
-    import shutil
     from difflib import SequenceMatcher
 except ImportError:
     textstat = None


### PR DESCRIPTION
## Summary
- simplify `__init__.py` imports and remove duplicates
- verify with flake8 that there are no unused imports

## Testing
- `flake8 tools/gitbook_worker/src/gitbook_worker/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_684c48924020832a96f0544adcc6dbce