### PR TITLE
Implement external reference repair

### DIFF
--- a/tools/gitbook_worker/tests/test_external_repair.py
+++ b/tools/gitbook_worker/tests/test_external_repair.py
@@ -9,11 +9,11 @@ def test_proof_and_repair_replaces_content(tmp_path, monkeypatch):
     def fake_extract(file):
         return {str(file): [{"Example": {"lineno": 4, "line": "1. Example https://example.com", "numbering": "1", "level": 2}}]}
 
-    def fake_proof(**kwargs):
-        return True, {"success": True, "new": "1. Example NEW", "validation_date": "2024-01-01", "type": "external reference", "hint": None}
+    def fake_ask(prompt, ai_url, ai_api_key, ai_provider):
+        return True, {"new": "1. Example NEW"}
 
     monkeypatch.setattr(source_extract, "extract_sources_of_a_md_file_to_dict", fake_extract)
-    monkeypatch.setattr(ai_tools, "proof_and_repair_external_reference", fake_proof)
+    monkeypatch.setattr(ai_tools, "ask_ai", fake_ask)
 
     ai_tools.proof_and_repair_external_references([str(md)], "", "", "", "")
 


### PR DESCRIPTION
## Summary
- implement JSON schema hint in `proof_and_repair_external_reference`
- update `proof_and_repair_external_references` to parse AI responses

## Testing
- `pip install -e tools/gitbook_worker`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da50c4ce4832aa2d975d6d1312c86