### PR TITLE
Add wide table preprocessing

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/__init__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__init__.py
@@ -11,7 +11,7 @@ except ImportError:  # pragma: no cover - optional dep
 
 __version__ = "2.0.0"
 
-from .utils import run, parse_summary, readability_report
+from .utils import run, parse_summary, readability_report, wrap_wide_tables
 from .linkcheck import (
     check_links,
     check_images,

--- a/tools/gitbook_worker/src/gitbook_worker/__main__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__main__.py
@@ -4,7 +4,7 @@ import io
 import os
 import logging
 from datetime import datetime
-from .utils import run, parse_summary, readability_report
+from .utils import run, parse_summary, readability_report, wrap_wide_tables
 from .linkcheck import (
     check_links,
     check_images,
@@ -59,6 +59,17 @@ def main():
         type=str,
         default="temp",
         help="Directory to place all temp results into.",
+    )
+    parser.add_argument(
+        "--wrap-wide-tables",
+        action="store_true",
+        help="Wrap tables wider than a threshold in a landscape environment.",
+    )
+    parser.add_argument(
+        "--table-threshold",
+        type=int,
+        default=6,
+        help="Number of columns considered wide for --wrap-wide-tables.",
     )
     parser.add_argument(
         "-s", "--export-sources", action="store_true", help="Export sources to CSV."
@@ -187,6 +198,9 @@ def main():
     except Exception as e:
         logging.error("Failed to write combined markdown: %s", e)
         sys.exit(1)
+
+    if args.wrap_wide_tables:
+        wrap_wide_tables(combined_md, threshold=args.table_threshold)
 
     if args.pdf:
         # Build PDF with Pandoc

--- a/tools/gitbook_worker/tests/test_wide_tables.py
+++ b/tools/gitbook_worker/tests/test_wide_tables.py
@@ -1,0 +1,19 @@
+from gitbook_worker.utils import wrap_wide_tables
+
+
+def test_wrap_wide_tables_adds_landscape(tmp_path):
+    md = tmp_path / "wide.md"
+    md.write_text("|A|B|C|D|E|F|G|\n|--|--|--|--|--|--|--|\n|1|2|3|4|5|6|7|\n")
+    wrap_wide_tables(str(md), threshold=5)
+    text = md.read_text()
+    assert text.startswith("\\begin{landscape}\n")
+    assert text.strip().endswith("\\end{landscape}")
+
+
+def test_wrap_wide_tables_ignores_narrow(tmp_path):
+    md = tmp_path / "narrow.md"
+    md.write_text("|A|B|\n|--|--|\n|1|2|\n")
+    wrap_wide_tables(str(md), threshold=5)
+    text = md.read_text()
+    assert "\\begin{landscape}" not in text
+    assert "\\end{landscape}" not in text


### PR DESCRIPTION
## Summary
- wrap wide Markdown tables in landscape before PDF generation
- expose new `wrap_wide_tables` helper
- add CLI flags `--wrap-wide-tables` and `--table-threshold`
- test wide table preprocessing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684edf23bf9c832a8303b020fd9bfe3b