### PR TITLE
Ensure A4 paper size for PDF

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/__main__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__main__.py
@@ -211,7 +211,7 @@ def main():
         # Add timestamp to output filename
         pdf_output = f"{pdf_output}_{timestamp}.pdf"
         out, err, code = run(
-            f'pandoc "{combined_md}" -o "{pdf_output}" --pdf-engine=xelatex --toc',
+            f'pandoc "{combined_md}" -o "{pdf_output}" --pdf-engine=xelatex --toc -V geometry:a4paper',
             capture_output=True,
         )
         if code != 0:


### PR DESCRIPTION
## Summary
- use DIN A4 geometry when generating the PDF in `gitbook-worker`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef7aebd74832aa408dd975f60b430