### PR TITLE
Fix landscape table rendering

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/__main__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__main__.py
@@ -268,7 +268,12 @@ def main():
             pdf_output = pdf_output[:-4]
         # Add timestamp to output filename
         pdf_output = f"{pdf_output}_{run_timestamp}.pdf"
-        pandoc_cmd = f'pandoc "{combined_md}" -o "{pdf_output}" --pdf-engine=xelatex --toc -V geometry:a4paper'
+        filter_path = os.path.join(os.path.dirname(__file__), "landscape.lua")
+        pandoc_cmd = (
+            f'pandoc "{combined_md}" -o "{pdf_output}" '
+            f'--pdf-engine=xelatex --toc -V geometry:a4paper '
+            f'--lua-filter="{filter_path}"'
+        )
         if header_file:
             pandoc_cmd += f' -H "{header_file}"'
         out, err, code = run(

--- a/tools/gitbook_worker/src/gitbook_worker/landscape.lua
+++ b/tools/gitbook_worker/src/gitbook_worker/landscape.lua
@@ -1,0 +1,14 @@
+function Div(el)
+  if el.classes:includes('landscape') then
+    if FORMAT:match('latex') then
+      local blocks = {pandoc.RawBlock('latex', '\\begin{landscape}')}
+      for _, b in ipairs(el.content) do
+        table.insert(blocks, b)
+      end
+      table.insert(blocks, pandoc.RawBlock('latex', '\\end{landscape}'))
+      return blocks
+    else
+      return el.content
+    end
+  end
+end

--- a/tools/gitbook_worker/src/gitbook_worker/utils.py
+++ b/tools/gitbook_worker/src/gitbook_worker/utils.py
@@ -66,12 +66,13 @@ def readability_report(md_files):
 
 
 def wrap_wide_tables(md_file: str, threshold: int = 6) -> None:
-    """Wrap wide markdown tables in a LaTeX landscape environment.
+    """Wrap wide markdown tables in a fenced ``Div`` with class ``landscape``.
 
     Consecutive lines starting with a pipe character are considered part of a
     table. If the table contains more columns than ``threshold`` it is wrapped
-    with ``\begin{landscape}`` and ``\end{landscape}`` markers. The file is
-    modified in place.
+    inside ``::: {.landscape}`` and ``:::` markers. A Pandoc Lua filter can
+    later convert this ``Div`` into the appropriate LaTeX ``landscape``
+    environment. The file is modified in place.
     """
 
     try:
@@ -93,9 +94,9 @@ def wrap_wide_tables(md_file: str, threshold: int = 6) -> None:
                 max_cols = max(max_cols, lines[i].count("|") - 1)
                 i += 1
             if max_cols > threshold:
-                new_lines.append("\\begin{landscape}\n")
+                new_lines.append("::: {.landscape}\n")
                 new_lines.extend(table)
-                new_lines.append("\\end{landscape}\n")
+                new_lines.append(":::\n")
             else:
                 new_lines.extend(table)
         else:

--- a/tools/gitbook_worker/tests/test_wide_tables.py
+++ b/tools/gitbook_worker/tests/test_wide_tables.py
@@ -6,8 +6,8 @@ def test_wrap_wide_tables_adds_landscape(tmp_path):
     md.write_text("|A|B|C|D|E|F|G|\n|--|--|--|--|--|--|--|\n|1|2|3|4|5|6|7|\n")
     wrap_wide_tables(str(md), threshold=5)
     text = md.read_text()
-    assert text.startswith("\\begin{landscape}\n")
-    assert text.strip().endswith("\\end{landscape}")
+    assert text.startswith("::: {.landscape}\n")
+    assert text.strip().endswith(":::")
 
 
 def test_wrap_wide_tables_ignores_narrow(tmp_path):
@@ -15,5 +15,5 @@ def test_wrap_wide_tables_ignores_narrow(tmp_path):
     md.write_text("|A|B|\n|--|--|\n|1|2|\n")
     wrap_wide_tables(str(md), threshold=5)
     text = md.read_text()
-    assert "\\begin{landscape}" not in text
-    assert "\\end{landscape}" not in text
+    assert "::: {.landscape}" not in text
+    assert ":::" not in text


### PR DESCRIPTION
## Summary
- wrap wide tables in fenced `Div` blocks instead of raw LaTeX so Pandoc parses the table
- add Lua filter to translate `Div` blocks with class `landscape` into `\begin{landscape}`/`\end{landscape}` in LaTeX
- update Pandoc command to use the filter
- adjust unit tests accordingly

## Testing
- `pip install -e .`
- `pytest -q`
- `gitbook-worker . --branch work --pdf test.pdf --wrap-wide-tables`

------
https://chatgpt.com/codex/tasks/task_e_6850478ce54c832a99195b7b6d6b2117