### PR TITLE
Fix packaging to include Lua filter

### DIFF
--- a/tools/gitbook_worker/pyproject.toml
+++ b/tools/gitbook_worker/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
 [project.scripts]
 gitbook-worker = "gitbook_worker.__main__:main"
 
+[tool.setuptools.package-data]
+"gitbook_worker" = ["landscape.lua"]
+
 [build-system]
 requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- ensure `landscape.lua` is packaged with gitbook-worker

## Testing
- `pip install . --force-reinstall` within `tools/gitbook_worker`
- `gitbook-worker . --branch work --pdf erda_buch.pdf --wrap-wide-tables -o run_output --temp-dir temp_run --clone-dir repo_clone --verbose`

------
https://chatgpt.com/codex/tasks/task_e_6856ad8dcdc8832a9379b3939ae16d2b