### PR TITLE
Improve gitbook_worker PDF export

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/__init__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__init__.py
@@ -11,7 +11,14 @@ except ImportError:  # pragma: no cover - optional dep
 
 __version__ = "2.0.0"
 
-from .utils import run, parse_summary, readability_report, wrap_wide_tables
+from .utils import (
+    run,
+    parse_summary,
+    readability_report,
+    wrap_wide_tables,
+    validate_table_columns,
+    download_remote_images,
+)
 from .linkcheck import (
     check_links,
     check_images,

--- a/tools/gitbook_worker/tests/test_download_images.py
+++ b/tools/gitbook_worker/tests/test_download_images.py
@@ -1,0 +1,25 @@
+import os
+from gitbook_worker.utils import download_remote_images
+
+class DummyResponse:
+    def __init__(self, content=b'x', status_code=200):
+        self.content = content
+        self.status_code = status_code
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception("bad status")
+
+def test_download_remote_images(tmp_path, monkeypatch):
+    md = tmp_path / "doc.md"
+    md.write_text("![](http://ex.com/a.png)")
+    dest = tmp_path / "imgs"
+
+    def fake_get(url, timeout=10):
+        return DummyResponse(b"data")
+
+    monkeypatch.setattr('gitbook_worker.utils.requests.get', fake_get)
+    count = download_remote_images(str(md), str(dest))
+    assert count == 1
+    text = md.read_text()
+    assert "ex.com" not in text
+    assert (dest / "a.png").exists()


### PR DESCRIPTION
## Summary
- handle remote images in PDFs
- set up emoji and table header with fontspec
- add pandoc options and detailed logging
- export helper in package
- test remote image download

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ecb7aedc832a90b01d9878600a1e