### PR TITLE
Handle download name conflicts

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/utils.py
+++ b/tools/gitbook_worker/src/gitbook_worker/utils.py
@@ -206,7 +206,12 @@ def download_remote_images(md_file: str, out_dir: str) -> int:
         try:
             os.makedirs(out_dir, exist_ok=True)
             name = os.path.basename(url.split("?")[0]) or f"img_{count}"
+            base, ext = os.path.splitext(name)
             dest = os.path.join(out_dir, name)
+            suffix = 1
+            while os.path.exists(dest):
+                dest = os.path.join(out_dir, f"{base}_{suffix}{ext}")
+                suffix += 1
             response = requests.get(url, timeout=10)
             response.raise_for_status()
             with open(dest, "wb") as wf:

--- a/tools/gitbook_worker/tests/test_download_images.py
+++ b/tools/gitbook_worker/tests/test_download_images.py
@@ -23,3 +23,27 @@ def test_download_remote_images(tmp_path, monkeypatch):
     text = md.read_text()
     assert "ex.com" not in text
     assert (dest / "a.png").exists()
+
+
+def test_download_remote_images_name_conflict(tmp_path, monkeypatch):
+    md = tmp_path / "doc.md"
+    md.write_text("![](http://ex.com/a.png)")
+    dest = tmp_path / "imgs"
+    dest.mkdir()
+    existing = dest / "a.png"
+    existing.write_text("old")
+
+    def fake_get(url, timeout=10):
+        return DummyResponse(b"data")
+
+    monkeypatch.setattr("gitbook_worker.utils.requests.get", fake_get)
+    count = download_remote_images(str(md), str(dest))
+    assert count == 1
+    # existing file must remain untouched
+    assert existing.read_text() == "old"
+    files = sorted(p.name for p in dest.iterdir())
+    assert "a.png" in files
+    files.remove("a.png")
+    assert len(files) == 1 and files[0].startswith("a_") and files[0].endswith(".png")
+    text = md.read_text()
+    assert os.path.join(str(dest), files[0]) in text


### PR DESCRIPTION
## Summary
- ensure `download_remote_images` creates unique filenames if a target already exists
- add regression test for name collision handling

## Testing
- `pytest -q tools/gitbook_worker/tests/test_download_images.py`
- `pytest -q tools/gitbook_worker/tests`

------
https://chatgpt.com/codex/tasks/task_e_686125cb1f94832abdcaf092709f592d