### PR TITLE
Fix typo in helper function

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/__init__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__init__.py
@@ -51,7 +51,7 @@ from .repo import (
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 
-def split_reference_to_decription_and_urluri(name: str) -> tuple[str, str]:
+def split_reference_to_description_and_urluri(name: str) -> tuple[str, str]:
     url_pattern = re.compile(r"\(?\[?(https?://[^\s\)\]\[]+|[^\s\)\]\[]+\.[^\s\)\]\[]+)\]?\)?")
     url_match = url_pattern.search(name)
     if url_match:


### PR DESCRIPTION
## Summary
- rename `split_reference_to_decription_and_urluri` to `split_reference_to_description_and_urluri`

## Testing
- `pytest -q tools/gitbook_worker/tests`

------
https://chatgpt.com/codex/tasks/task_e_686125c64aa8832aa6e3e13ed3d33e37