### PR TITLE
Add font customization options to gitbook_worker

### DIFF
--- a/tools/gitbook_worker/README.md
+++ b/tools/gitbook_worker/README.md
@@ -48,6 +48,11 @@ geben Sie der PDF-Engine eine passende Schriftart an, z.B.:
 pandoc input.md -o output.pdf --pdf-engine=xelatex -V mainfont="Noto Color Emoji"
 ```
 
+Ab Version 2.1 kann `gitbook_worker` das Emoji-Font automatisch setzen. Mit
+`--emoji-color` verwenden Sie eine Farbschriftart (standardmäßig wird eine
+schwarz-weiße Emoji-Schrift genutzt). Über `--main-font` lässt sich zudem die
+Hauptschriftart festlegen.
+
 ## 3. Beispiele: PDF-Erzeugung mit gitbook_worker
 
 Hier einige typische Workflows, wie Sie mit `gitbook_worker` ein PDF erzeugen:
@@ -62,6 +67,8 @@ gitbook-worker -v \
   https://github.com/Rob9999/erda-book.git \
   --branch release_candidate \
   --wrap-wide-tables \
+  --emoji-color \
+  --main-font "Noto Serif" \
   --pdf "C:/RAMProjects/ERDA/repo/Erda Buch"
 ```
 
@@ -75,6 +82,8 @@ gitbook-worker -v \
   https://github.com/Rob9999/erda-book.git \
   --branch release_candidate \
   --wrap-wide-tables \
+  --emoji-color \
+  --main-font "Noto Serif" \
   --use-docker \
   --pdf "C:/RAMProjects/ERDA/repo/Erda Buch"
 ```

--- a/tools/gitbook_worker/pyproject.toml
+++ b/tools/gitbook_worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gitbook-worker"
-version = "2.0.0"
+version = "2.1.0"
 description = "Utilities to process GitBook repositories"
 authors = [
     {name = "ERDA", email = "info@example.com"}

--- a/tools/gitbook_worker/src/gitbook_worker/__init__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__init__.py
@@ -9,7 +9,7 @@ try:
 except ImportError:  # pragma: no cover - optional dep
     yaml = None
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 from .utils import (
     run,

--- a/tools/gitbook_worker/src/gitbook_worker/__main__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__main__.py
@@ -96,6 +96,17 @@ def main():
         help="Number of columns considered wide for --wrap-wide-tables.",
     )
     parser.add_argument(
+        "--main-font",
+        type=str,
+        default="DejaVu Serif",
+        help="Main font for the generated PDF.",
+    )
+    parser.add_argument(
+        "--emoji-color",
+        action="store_true",
+        help="Render emojis using a color font instead of monochrome.",
+    )
+    parser.add_argument(
         "-s", "--export-sources", action="store_true", help="Export sources to CSV."
     )
     parser.add_argument(
@@ -288,11 +299,12 @@ def main():
             ensure_docker_image("erda-pandoc", dockerfile_path)
             logging.info("Preparing pandoc header tex file...")
             header_file = os.path.join(temp_dir, "pandoc_header.tex")
+            emoji_font = "Noto Color Emoji" if args.emoji_color else "OpenMoji Black"
             try:
                 with open(header_file, "w", encoding="utf-8") as hf:
                     hf.write("\\usepackage{fontspec}\n")
-                    hf.write("\\setmainfont{DejaVu Serif}\n")
-                    hf.write("\\newfontfamily\\EmojiOne{OpenMoji Black}\n")
+                    hf.write(f"\\setmainfont{{{args.main_font}}}\\n")
+                    hf.write(f"\\newfontfamily\\EmojiOne{{{emoji_font}}}\\n")
                     if args.wrap_wide_tables:
                         logging.info("Wrapping wide tables in landscape environment...")
                         wrap_wide_tables(combined_md, threshold=args.table_threshold)
@@ -354,11 +366,12 @@ def main():
             filter_path = os.path.join(os.path.dirname(__file__), "landscape.lua")
             logging.info("Preparing pandoc header tex file...")
             header_file = os.path.join(temp_dir, "pandoc_header.tex")
+            emoji_font = "Noto Color Emoji" if args.emoji_color else "Segoe UI Emoji"
             try:
                 with open(header_file, "w", encoding="utf-8") as hf:
                     hf.write("\\usepackage{fontspec}\n")
-                    hf.write("\\setmainfont{DejaVu Serif}\n")
-                    hf.write("\\newfontfamily\\EmojiOne{Segoe UI Emoji}\n")
+                    hf.write(f"\\setmainfont{{{args.main_font}}}\\n")
+                    hf.write(f"\\newfontfamily\\EmojiOne{{{emoji_font}}}\\n")
                     if args.wrap_wide_tables:
                         logging.info("Wrapping wide tables in landscape environment...")
                         wrap_wide_tables(combined_md, threshold=args.table_threshold)


### PR DESCRIPTION
## Summary
- add `--main-font` and `--emoji-color` CLI options in gitbook_worker
- honour the options when creating the PDF header
- document font selection in README
- bump version to 2.1.0

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643458404c832a980880b47044feda