### PR TITLE
Refactor pandoc header creation

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/__main__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__main__.py
@@ -11,6 +11,7 @@ from .utils import (
     wrap_wide_tables,
     validate_table_columns,
     download_remote_images,
+    _write_pandoc_header,
 )
 from .linkcheck import (
     check_links,
@@ -310,26 +311,21 @@ def main():
             )
             ensure_docker_image("erda-pandoc", dockerfile_path)
             logging.info("Preparing pandoc header tex file...")
-            header_file = os.path.join(temp_dir, "pandoc_header.tex")
             emoji_font = "OpenMoji Color" if args.emoji_color else "OpenMoji Black"
             try:
-                with open(header_file, "w", encoding="utf-8") as hf:
-                    hf.write("\\usepackage{fontspec}\n")
-                    hf.write(f"\\setsansfont{{{args.sans_font}}}\n")
-                    hf.write(f"\\setmonofont{{{args.mono_font}}}\n")
-                    hf.write(f"\\setmainfont{{{args.main_font}}}\n")
-                    hf.write(
-                        f"\\newfontfamily\\EmojiOne{{{emoji_font}}}[Range={{1F300-1F5FF, 1F600-1F64F, 1F680-1F6FF, 1F700-1F77F, 1F780-1F7FF, 1F800-1F8FF, 1F900-1F9FF, 1FA00-1FA6F, 1FA70-1FAFF, 2600-26FF, 2700-27BF, 2300-23FF, 2B50, 2B06, 2934-2935, 25A0-25FF}}]\n"
-                    )
-                    if args.wrap_wide_tables:
-                        logging.info("Wrapping wide tables in landscape environment...")
-                        wrap_wide_tables(combined_md, threshold=args.table_threshold)
-                        hf.write("\\usepackage{pdflscape}\n")
-                        logging.info("Wide tables wrapped successfully.")
+                header_file = _write_pandoc_header(
+                    temp_dir,
+                    emoji_font,
+                    args.sans_font,
+                    args.mono_font,
+                    args.main_font,
+                    args.wrap_wide_tables,
+                    args.table_threshold,
+                    combined_md,
+                )
             except Exception as e:
                 logging.error("Failed to write pandoc header tex file: %s", e)
                 sys.exit(1)
-            logging.info("Pandoc header tex file created: %s", header_file)
             abs_out_dir = os.path.abspath(out_dir)
             abs_temp_dir = os.path.abspath(temp_dir)
             abs_clone_dir = os.path.abspath(clone_dir)
@@ -381,26 +377,21 @@ def main():
             logging.info("Building PDF with Pandoc...")
             filter_path = os.path.join(os.path.dirname(__file__), "landscape.lua")
             logging.info("Preparing pandoc header tex file...")
-            header_file = os.path.join(temp_dir, "pandoc_header.tex")
-            emoji_font = "Segoe UI Emoji" if args.emoji_color else "Segoe UI Emoji"
+            emoji_font = "Segoe UI Emoji"
             try:
-                with open(header_file, "w", encoding="utf-8") as hf:
-                    hf.write("\\usepackage{fontspec}\n")
-                    hf.write(f"\\setsansfont{{{args.sans_font}}}\n")
-                    hf.write(f"\\setmonofont{{{args.mono_font}}}\n")
-                    hf.write(f"\\setmainfont{{{args.main_font}}}\n")
-                    hf.write(
-                        f"\\newfontfamily\\EmojiOne{{{emoji_font}}}[Range={{1F300-1F5FF, 1F600-1F64F, 1F680-1F6FF, 1F700-1F77F, 1F780-1F7FF, 1F800-1F8FF, 1F900-1F9FF, 1FA00-1FA6F, 1FA70-1FAFF, 2600-26FF, 2700-27BF, 2300-23FF, 2B50, 2B06, 2934-2935, 25A0-25FF}}]\n"
-                    )
-                    if args.wrap_wide_tables:
-                        logging.info("Wrapping wide tables in landscape environment...")
-                        wrap_wide_tables(combined_md, threshold=args.table_threshold)
-                        hf.write("\\usepackage{pdflscape}\n")
-                        logging.info("Wide tables wrapped successfully.")
+                header_file = _write_pandoc_header(
+                    temp_dir,
+                    emoji_font,
+                    args.sans_font,
+                    args.mono_font,
+                    args.main_font,
+                    args.wrap_wide_tables,
+                    args.table_threshold,
+                    combined_md,
+                )
             except Exception as e:
                 logging.error("Failed to write pandoc header tex file: %s", e)
                 sys.exit(1)
-            logging.info("Pandoc header tex file created: %s", header_file)
             pandoc_cmd = [
                 "pandoc",
                 combined_md,

--- a/tools/gitbook_worker/src/gitbook_worker/utils.py
+++ b/tools/gitbook_worker/src/gitbook_worker/utils.py
@@ -233,3 +233,39 @@ def download_remote_images(md_file: str, out_dir: str) -> int:
             logging.error("Failed to write %s: %s", md_file, e)
             raise
     return count
+
+
+def _write_pandoc_header(
+    temp_dir: str,
+    emoji_font: str,
+    sans_font: str,
+    mono_font: str,
+    main_font: str,
+    wrap_tables: bool,
+    threshold: int,
+    md_file: str,
+) -> str:
+    """Create a temporary pandoc header file and optionally wrap wide tables.
+
+    Returns the path to the created header file."""
+
+    header_file = os.path.join(temp_dir, "pandoc_header.tex")
+    try:
+        with open(header_file, "w", encoding="utf-8") as hf:
+            hf.write("\\usepackage{fontspec}\n")
+            hf.write(f"\\setsansfont{{{sans_font}}}\n")
+            hf.write(f"\\setmonofont{{{mono_font}}}\n")
+            hf.write(f"\\setmainfont{{{main_font}}}\n")
+            hf.write(
+                f"\\newfontfamily\\EmojiOne{{{emoji_font}}}[Range={{1F300-1F5FF, 1F600-1F64F, 1F680-1F6FF, 1F700-1F77F, 1F780-1F7FF, 1F800-1F8FF, 1F900-1F9FF, 1FA00-1FA6F, 1FA70-1FAFF, 2600-26FF, 2700-27BF, 2300-23FF, 2B50, 2B06, 2934-2935, 25A0-25FF}}]\n"
+            )
+            if wrap_tables:
+                logging.info("Wrapping wide tables in landscape environment...")
+                wrap_wide_tables(md_file, threshold=threshold)
+                hf.write("\\usepackage{pdflscape}\n")
+                logging.info("Wide tables wrapped successfully.")
+    except Exception as e:
+        logging.error("Failed to write pandoc header tex file: %s", e)
+        raise
+    logging.info("Pandoc header tex file created: %s", header_file)
+    return header_file

--- a/tools/gitbook_worker/tests/test_header.py
+++ b/tools/gitbook_worker/tests/test_header.py
@@ -1,0 +1,47 @@
+import os
+from gitbook_worker.utils import _write_pandoc_header
+
+def test_write_pandoc_header_creates_file(tmp_path):
+    md = tmp_path / "combined.md"
+    md.write_text("text")
+    header = _write_pandoc_header(
+        str(tmp_path),
+        "OpenMoji Color",
+        "Sans",
+        "Mono",
+        "Main",
+        False,
+        6,
+        str(md),
+    )
+    assert os.path.isfile(header)
+    content = open(header, encoding="utf-8").read()
+    assert "\\usepackage{fontspec}" in content
+    assert "\\setsansfont{Sans}" in content
+    assert "\\setmonofont{Mono}" in content
+    assert "\\setmainfont{Main}" in content
+    assert "\\newfontfamily\\EmojiOne{OpenMoji Color}" in content
+
+
+def test_write_pandoc_header_wrap_tables(tmp_path, monkeypatch):
+    md = tmp_path / "tables.md"
+    md.write_text("|A|B|C|D|E|F|G|\n|--|--|--|--|--|--|--|\n|1|2|3|4|5|6|7|\n")
+    called = {}
+    def fake_wrap(md_file, threshold):
+        called['md'] = md_file
+        called['th'] = threshold
+    monkeypatch.setattr('gitbook_worker.utils.wrap_wide_tables', fake_wrap)
+    header = _write_pandoc_header(
+        str(tmp_path),
+        "Segoe UI Emoji",
+        "Sans",
+        "Mono",
+        "Main",
+        True,
+        5,
+        str(md),
+    )
+    assert called == {'md': str(md), 'th': 5}
+    content = open(header, encoding="utf-8").read()
+    assert "\\usepackage{pdflscape}" in content
+


### PR DESCRIPTION
## Summary
- factor out pandoc header file generation into `_write_pandoc_header`
- use the helper in both Docker and non‑Docker flows
- test new helper for basic functionality and table wrapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68657be57688832a918bef32e50c4eae