### PR TITLE
Add shared emoji range constant

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/utils.py
+++ b/tools/gitbook_worker/src/gitbook_worker/utils.py
@@ -6,6 +6,13 @@ import logging
 from typing import List
 import requests
 
+# Emoji ranges supported by the LaTeX header
+EMOJI_RANGES = (
+    "1F300-1F5FF, 1F600-1F64F, 1F680-1F6FF, 1F700-1F77F, 1F780-1F7FF, "
+    "1F800-1F8FF, 1F900-1F9FF, 1FA00-1FA6F, 1FA70-1FAFF, "
+    "2600-26FF, 2700-27BF, 2300-23FF, 2B50, 2B06, 2934-2935, 25A0-25FF"
+)
+
 try:
     import textstat
 except ImportError:  # pragma: no cover - optional dep
@@ -257,7 +264,7 @@ def _write_pandoc_header(
             hf.write(f"\\setmonofont{{{mono_font}}}\n")
             hf.write(f"\\setmainfont{{{main_font}}}\n")
             hf.write(
-                f"\\newfontfamily\\EmojiOne{{{emoji_font}}}[Range={{1F300-1F5FF, 1F600-1F64F, 1F680-1F6FF, 1F700-1F77F, 1F780-1F7FF, 1F800-1F8FF, 1F900-1F9FF, 1FA00-1FA6F, 1FA70-1FAFF, 2600-26FF, 2700-27BF, 2300-23FF, 2B50, 2B06, 2934-2935, 25A0-25FF}}]\n"
+                f"\\newfontfamily\\EmojiOne{{{emoji_font}}}[Range={{{EMOJI_RANGES}}}]\n"
             )
             if wrap_tables:
                 logging.info("Wrapping wide tables in landscape environment...")

--- a/tools/gitbook_worker/tests/test_header.py
+++ b/tools/gitbook_worker/tests/test_header.py
@@ -1,5 +1,5 @@
 import os
-from gitbook_worker.utils import _write_pandoc_header
+from gitbook_worker.utils import _write_pandoc_header, EMOJI_RANGES
 
 def test_write_pandoc_header_creates_file(tmp_path):
     md = tmp_path / "combined.md"
@@ -20,7 +20,8 @@ def test_write_pandoc_header_creates_file(tmp_path):
     assert "\\setsansfont{Sans}" in content
     assert "\\setmonofont{Mono}" in content
     assert "\\setmainfont{Main}" in content
-    assert "\\newfontfamily\\EmojiOne{OpenMoji Color}" in content
+    expected = f"\\newfontfamily\\EmojiOne{{OpenMoji Color}}[Range={{{EMOJI_RANGES}}}]"
+    assert expected in content
 
 
 def test_write_pandoc_header_wrap_tables(tmp_path, monkeypatch):
@@ -44,4 +45,5 @@ def test_write_pandoc_header_wrap_tables(tmp_path, monkeypatch):
     assert called == {'md': str(md), 'th': 5}
     content = open(header, encoding="utf-8").read()
     assert "\\usepackage{pdflscape}" in content
+    assert f"\\newfontfamily\\EmojiOne{{Segoe UI Emoji}}[Range={{{EMOJI_RANGES}}}]" in content
 


### PR DESCRIPTION
## Summary
- introduce `EMOJI_RANGES` in utils for LaTeX emoji font selection
- use the constant when writing the pandoc header
- update tests to assert the range string via the new constant

## Testing
- `pip install requests tqdm PyYAML textstat`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686782a2bbb4832ab67465b0dfdb79e6