### PR TITLE
Add Docker Desktop management

### DIFF
--- a/tools/gitbook_worker/README.md
+++ b/tools/gitbook_worker/README.md
@@ -74,6 +74,9 @@ gitbook-worker -v \
 
 ### 2. ERDA Buch als PDF mit Docker erzeugen
 
+Auf Windows-Systemen startet `gitbook_worker` Docker Desktop automatisch,
+falls es noch nicht ausgeführt wird.
+
 ```bash
 gitbook-worker -v \
   --clone-dir C:/RAMProjects/ERDA/repo/gitbook_repo \

--- a/tools/gitbook_worker/src/gitbook_worker/__main__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__main__.py
@@ -26,7 +26,7 @@ from .ai_tools import (
     proof_and_repair_external_references,
 )
 from .repo import clone_or_update_repo
-from .docker_tools import ensure_docker_image
+from .docker_tools import ensure_docker_image, ensure_docker_desktop
 from . import lint_markdown, validate_metadata, spellcheck
 
 
@@ -304,6 +304,7 @@ def main():
         if args.use_docker:
             # Docker-Workflow
             logging.info("Using Docker to build PDF...")
+            ensure_docker_desktop()
             dockerfile_path = os.path.join(
                 os.path.dirname(__file__),
                 "Dockerfile",

--- a/tools/gitbook_worker/src/gitbook_worker/docker_tools.py
+++ b/tools/gitbook_worker/src/gitbook_worker/docker_tools.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import sys
 import logging
+import platform
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -34,3 +36,59 @@ def ensure_docker_image(image_name, dockerfile_path) -> None:
         if build_result.returncode != 0:
             logger.error("Docker build failed:\n%s", build_result.stderr)
             sys.exit(1)
+
+
+def get_os() -> str:
+    """Return the current operating system name."""
+    return platform.system()
+
+
+def ensure_docker_desktop() -> None:
+    """Ensure Docker Desktop is running on Windows."""
+    if get_os() != "Windows":
+        return
+
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if result.returncode == 0:
+            return
+    except FileNotFoundError:
+        logger.error("Docker executable not found")
+        return
+
+    docker_path = os.path.expandvars(
+        r"%ProgramFiles%\\Docker\\Docker\\Docker Desktop.exe"
+    )
+    if not os.path.exists(docker_path):
+        logger.error("Docker Desktop executable not found: %s", docker_path)
+        return
+
+    logger.info("Starting Docker Desktop ...")
+    try:
+        subprocess.Popen(
+            [docker_path],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception as exc:  # pragma: no cover - environment dependent
+        logger.error("Failed to start Docker Desktop: %s", exc)
+        return
+
+    for _ in range(15):  # wait up to ~30 seconds
+        time.sleep(2)
+        ping = subprocess.run(
+            ["docker", "info"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if ping.returncode == 0:
+            logger.info("Docker Desktop started")
+            return
+
+    logger.error("Docker Desktop did not start in time")

--- a/tools/gitbook_worker/tests/test_docker_tools.py
+++ b/tools/gitbook_worker/tests/test_docker_tools.py
@@ -1,0 +1,46 @@
+import platform
+import types
+from gitbook_worker import docker_tools
+
+
+def test_get_os_matches_platform():
+    assert docker_tools.get_os() == platform.system()
+
+
+def test_ensure_docker_desktop_non_windows(monkeypatch):
+    monkeypatch.setattr(docker_tools, "get_os", lambda: "Linux")
+    called = {}
+
+    def fake_run(cmd, stdout=None, stderr=None, text=True):
+        called['run'] = True
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(docker_tools.subprocess, "run", fake_run)
+    docker_tools.ensure_docker_desktop()
+    # on non Windows systems docker should not be invoked
+    assert 'run' not in called
+
+
+def test_ensure_docker_desktop_starts(monkeypatch):
+    monkeypatch.setattr(docker_tools, "get_os", lambda: "Windows")
+    runs = {"count": 0}
+
+    def fake_run(cmd, stdout=None, stderr=None, text=True):
+        runs["count"] += 1
+        # first call fails, second succeeds
+        return types.SimpleNamespace(returncode=0 if runs["count"] > 1 else 1)
+
+    popen_called = {}
+
+    class DummyPopen:
+        def __init__(self, *a, **kw):
+            popen_called['called'] = True
+
+    monkeypatch.setattr(docker_tools.subprocess, "run", fake_run)
+    monkeypatch.setattr(docker_tools.os.path, "exists", lambda p: True)
+    monkeypatch.setattr(docker_tools.subprocess, "Popen", DummyPopen)
+    monkeypatch.setattr(docker_tools.time, "sleep", lambda x: None)
+
+    docker_tools.ensure_docker_desktop()
+    assert popen_called.get('called')
+    assert runs["count"] >= 2


### PR DESCRIPTION
## Summary
- detect host OS and add Docker Desktop checks
- start Docker Desktop on Windows if needed
- document automatic startup behaviour
- use Docker Desktop check when building the PDF
- test docker tools

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68678aae5b08832a9fb312f12858c7b5