### PR TITLE
Add Pandoc version helpers and emoji fallback options

### DIFF
--- a/tools/gitbook_worker/tests/test_header.py
+++ b/tools/gitbook_worker/tests/test_header.py
@@ -45,5 +45,23 @@ def test_write_pandoc_header_wrap_tables(tmp_path, monkeypatch):
     assert called == {'md': str(md), 'th': 5}
     content = open(header, encoding="utf-8").read()
     assert "\\usepackage{pdflscape}" in content
-    assert f"\\newfontfamily\\EmojiOne{{Segoe UI Emoji}}[Range={{{EMOJI_RANGES}}}]" in content
+    assert "\\IfFontExistsTF{Segoe UI Emoji}" in content
+    assert "luaotfload.add_fallback(\"mainfont\", \"Segoe UI Emoji:mode=harf\")" in content
+
+
+def test_write_pandoc_header_no_emoji(tmp_path):
+    md = tmp_path / "file.md"
+    md.write_text("t")
+    header = _write_pandoc_header(
+        str(tmp_path),
+        "",
+        "Sans",
+        "Mono",
+        "Main",
+        False,
+        6,
+        str(md),
+    )
+    content = open(header, encoding="utf-8").read()
+    assert "EmojiOne" not in content
 

--- a/tools/gitbook_worker/tests/test_utils.py
+++ b/tools/gitbook_worker/tests/test_utils.py
@@ -1,0 +1,13 @@
+import shutil
+import pytest
+from gitbook_worker.utils import get_pandoc_version, font_available
+
+@pytest.mark.skipif(shutil.which("pandoc") is None, reason="pandoc not installed")
+def test_get_pandoc_version_format():
+    version = get_pandoc_version()
+    assert isinstance(version, tuple)
+    assert all(isinstance(v, int) for v in version)
+
+
+def test_font_available_false():
+    assert font_available("DefinitelyMissingFontXYZ") is False


### PR DESCRIPTION
## Summary
- add `get_pandoc_version` and `font_available` helper utilities
- enhance `_write_pandoc_header` with optional emoji handling and Segoe UI fallback
- choose Pandoc emoji strategy based on version in `__main__`
- add tests for new helpers and header logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867a8b42b1c832aa875f42677a275fc