### PR TITLE
Update gitbook_worker README

### DIFF
--- a/tools/gitbook_worker/README.md
+++ b/tools/gitbook_worker/README.md
@@ -57,6 +57,12 @@ noch nicht. `gitbook_worker` erzeugt in diesem Fall eine LaTeX-Präambel mit
 Sie dazu den Schalter `--emoji-color` und passen Sie bei Bedarf `--main-font`
 an.
 
+`gitbook_worker` erkennt dabei die installierte Pandoc-Version und setzt
+`mainfontfallback` nur ein, wenn es bereits unterstützt wird. Bei älteren
+Versionen fügt das Programm stattdessen eine kurze LuaTeX-Anweisung ein, damit
+Segoe UI Emoji als Fallback dient. Im Docker-Workflow kommen weiterhin die
+OpenMoji-Schriftarten des Containers zum Einsatz.
+
 ## 3. Beispiele: PDF-Erzeugung mit gitbook_worker
 
 Hier einige typische Workflows, wie Sie mit `gitbook_worker` ein PDF erzeugen:


### PR DESCRIPTION
## Summary
- explain fallback handling in the Emoji section
- note continued use of OpenMoji fonts in the Docker image

## Testing
- `make html`

------
https://chatgpt.com/codex/tasks/task_e_6867a8bef184832a9b12ec14f4d7f053