### PR TITLE
Improve pandoc font handling

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/__main__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__main__.py
@@ -392,11 +392,21 @@ def main():
                         args.wrap_wide_tables,
                         args.table_threshold,
                         combined_md,
+                        write_mainfont=False,
                     )
                 except Exception as e:
                     logging.error("Failed to write pandoc header tex file: %s", e)
                     sys.exit(1)
-                extra = ["-V", "mainfontfallback=Segoe UI Emoji:mode=harf"]
+                extra = [
+                    "-V",
+                    "mainfontfallback=Segoe UI Emoji:mode=harf",
+                    "-V",
+                    f"mainfont={args.main_font}",
+                    "-V",
+                    f"sansfont={args.sans_font}",
+                    "-V",
+                    f"monofont={args.mono_font}",
+                ]
             else:
                 logging.info("Using manual Segoe UI Emoji fallback")
                 try:

--- a/tools/gitbook_worker/src/gitbook_worker/utils.py
+++ b/tools/gitbook_worker/src/gitbook_worker/utils.py
@@ -281,8 +281,13 @@ def _write_pandoc_header(
     wrap_tables: bool,
     threshold: int,
     md_file: str,
+    write_mainfont: bool = True,
 ) -> str:
     """Create a temporary pandoc header file and optionally wrap wide tables.
+
+    ``write_mainfont`` controls whether a ``\setmainfont`` command is written
+    to the header. This is useful for pandoc ``>= 3.1.12`` where the main font
+    can be supplied via ``-V mainfont=...``.
 
     Returns the path to the created header file."""
 
@@ -292,7 +297,8 @@ def _write_pandoc_header(
             hf.write("\\usepackage{fontspec}\n")
             hf.write(f"\\setsansfont{{{sans_font}}}\n")
             hf.write(f"\\setmonofont{{{mono_font}}}\n")
-            hf.write(f"\\setmainfont{{{main_font}}}\n")
+            if write_mainfont:
+                hf.write(f"\\setmainfont{{{main_font}}}\n")
             if emoji_font:
                 if emoji_font.startswith("OpenMoji"):
                     hf.write(

--- a/tools/gitbook_worker/tests/test_header.py
+++ b/tools/gitbook_worker/tests/test_header.py
@@ -65,3 +65,23 @@ def test_write_pandoc_header_no_emoji(tmp_path):
     content = open(header, encoding="utf-8").read()
     assert "EmojiOne" not in content
 
+
+def test_write_pandoc_header_skip_mainfont(tmp_path):
+    md = tmp_path / "file.md"
+    md.write_text("x")
+    header = _write_pandoc_header(
+        str(tmp_path),
+        "",
+        "Sans",
+        "Mono",
+        "Main",
+        False,
+        6,
+        str(md),
+        write_mainfont=False,
+    )
+    content = open(header, encoding="utf-8").read()
+    assert "\\setsansfont{Sans}" in content
+    assert "\\setmonofont{Mono}" in content
+    assert "\\setmainfont" not in content
+


### PR DESCRIPTION
## Summary
- allow `_write_pandoc_header` to skip `\setmainfont`
- add CLI font variables for pandoc >=3.1.12
- test skipping of `\setmainfont`

## Testing
- `pytest -q tools/gitbook_worker/tests`

------
https://chatgpt.com/codex/tasks/task_e_686800f4bfcc832a8c134414793d28ac