### PR TITLE
Add emoji report feature to gitbook_worker

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/__init__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__init__.py
@@ -18,6 +18,7 @@ from .utils import (
     wrap_wide_tables,
     validate_table_columns,
     download_remote_images,
+    emoji_report,
 )
 from .linkcheck import (
     check_links,

--- a/tools/gitbook_worker/src/gitbook_worker/__main__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__main__.py
@@ -13,6 +13,7 @@ from .utils import (
     download_remote_images,
     _write_pandoc_header,
     get_pandoc_version,
+    emoji_report,
 )
 from .linkcheck import (
     check_links,
@@ -152,6 +153,12 @@ def main():
     )
     parser.add_argument(
         "-p", "--spellcheck", action="store_true", help="Run spellchecker."
+    )
+    parser.add_argument(
+        "-E",
+        "--emoji-report",
+        action="store_true",
+        help="Analyze emoji usage and write a markdown report.",
     )
     parser.add_argument(
         "--fix-internal-links",
@@ -558,6 +565,23 @@ def main():
         except Exception as e:
             logging.error("spellcheck failed: %s", e)
             logger.error("Error running spellcheck: %s", e)
+    if args.emoji_report:
+        logging.info("emoji-report started")
+        try:
+            counts, table_md = emoji_report(combined_md)
+            for name, count in counts.items():
+                logger.info("Emoji %s: %s", name, count)
+            report_filename = os.path.join(
+                out_dir, f"emoji_report_{run_timestamp}.md"
+            )
+            with open(report_filename, "w", encoding="utf-8") as rf:
+                rf.write("# Emoji Report\n\n")
+                rf.write(table_md + "\n")
+            logger.info("Emoji report written to %s", report_filename)
+            logging.info("emoji-report done")
+        except Exception as e:
+            logging.error("emoji-report failed: %s", e)
+            logger.error("Error generating emoji report: %s", e)
     if args.fix_internal_links:
         logging.info("fix-internal-links started")
         try:

--- a/tools/gitbook_worker/src/gitbook_worker/utils.py
+++ b/tools/gitbook_worker/src/gitbook_worker/utils.py
@@ -327,3 +327,49 @@ def _write_pandoc_header(
         raise
     logging.info("Pandoc header tex file created: %s", header_file)
     return header_file
+
+
+EMOJI_BLOCKS = [
+    ("Emoticons", 0x1F600, 0x1F64F),
+    ("Transport and Map Symbols", 0x1F680, 0x1F6FF),
+    ("Misc Symbols and Pictographs", 0x1F300, 0x1F5FF),
+    ("Supplemental Symbols and Pictographs", 0x1F900, 0x1F9FF),
+    ("Symbols and Pictographs Extended-A", 0x1FA70, 0x1FAFF),
+    ("Miscellaneous Symbols", 0x2600, 0x26FF),
+    ("Dingbats", 0x2700, 0x27BF),
+    ("Flags", 0x1F1E6, 0x1F1FF),
+    ("Alchemical Symbols", 0x1F700, 0x1F77F),
+    ("Enclosed Alphanumeric Supplement", 0x1F100, 0x1F1FF),
+]
+
+
+def emoji_report(md_file: str) -> tuple[dict, str]:
+    """Return emoji usage counts and a markdown table for ``md_file``."""
+
+    try:
+        with open(md_file, encoding="utf-8") as file:
+            text = file.read()
+    except Exception as e:  # pragma: no cover - unlikely
+        logging.error("Failed to read %s: %s", md_file, e)
+        raise
+
+    emoji_pattern = re.compile(r"[^\u0000-\u007F\u00A0-\u024F]+")
+    emojis = [c for group in emoji_pattern.findall(text) for c in group]
+
+    counts: dict[str, int] = defaultdict(int)
+    for char in emojis:
+        cp = ord(char)
+        block = "Unknown"
+        for name, start, end in EMOJI_BLOCKS:
+            if start <= cp <= end:
+                block = name
+                break
+        counts[block] += 1
+
+    rows = sorted(counts.items(), key=lambda x: (-x[1], x[0]))
+    lines = ["| Unicode Block | Count |", "| --- | --- |"]
+    for name, count in rows:
+        lines.append(f"| {name} | {count} |")
+    table_md = "\n".join(lines)
+
+    return dict(counts), table_md

--- a/tools/gitbook_worker/tests/test_emoji_report.py
+++ b/tools/gitbook_worker/tests/test_emoji_report.py
@@ -1,0 +1,12 @@
+import os
+from gitbook_worker import emoji_report
+
+
+def test_emoji_report_counts(tmp_path):
+    md = tmp_path / "file.md"
+    md.write_text("Hello 😊 world 🚀")
+    counts, table = emoji_report(str(md))
+    assert counts.get("Emoticons") == 1
+    assert counts.get("Transport and Map Symbols") == 1
+    assert "| Unicode Block |" in table
+    assert "Transport and Map Symbols" in table


### PR DESCRIPTION
## Summary
- introduce `emoji_report` in utils for analyzing emoji usage
- export the function in package init
- add `--emoji-report` CLI option and logging
- test emoji report counts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68687ef671e4832a968b6bf74b0e2227