### PR TITLE
Fix PDF build workflow

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/__main__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__main__.py
@@ -335,7 +335,7 @@ def main():
             except Exception as e:
                 logging.error("Failed to write pandoc header tex file: %s", e)
                 sys.exit(1)
-            filter_path = os.path.join(os.path.dirname(__file__), "landscape.lua")
+            filter_path = "" if args.wrap_wide_tables else os.path.join(os.path.dirname(__file__), "landscape.lua")
             docker_cmd = build_docker_pandoc_cmd(
                 out_dir,
                 temp_dir,
@@ -350,7 +350,7 @@ def main():
         else:
             # Non-Docker workflow
             logging.info("Building PDF with Pandoc...")
-            filter_path = os.path.join(os.path.dirname(__file__), "landscape.lua")
+            filter_path = "" if args.wrap_wide_tables else os.path.join(os.path.dirname(__file__), "landscape.lua")
             version = get_pandoc_version()
             logging.info("Detected pandoc version: %s", ".".join(map(str, version)))
             logging.info("Preparing pandoc header tex file...")

--- a/tools/gitbook_worker/src/gitbook_worker/pandoc_utils.py
+++ b/tools/gitbook_worker/src/gitbook_worker/pandoc_utils.py
@@ -34,8 +34,10 @@ def build_docker_pandoc_cmd(
         f"{abs_temp_dir}:{docker_temp_dir}",
         "-v",
         f"{abs_clone_dir}:{docker_clone_dir}",
-        "-v",
-        f"{os.path.dirname(filter_path)}:/filters",
+    ]
+    if filter_path:
+        cmd += ["-v", f"{os.path.dirname(filter_path)}:/filters"]
+    cmd += [
         "erda-pandoc",
         docker_combined_md,
         "-o",
@@ -49,8 +51,9 @@ def build_docker_pandoc_cmd(
         f"--resource-path={docker_clone_dir}",
         "-H",
         docker_header_file,
-        f"--lua-filter=/filters/{os.path.basename(filter_path)}",
     ]
+    if filter_path:
+        cmd.append(f"--lua-filter=/filters/{os.path.basename(filter_path)}")
     return cmd
 
 
@@ -77,14 +80,10 @@ def build_pandoc_cmd(
     ]
     if extra_args:
         cmd.extend(extra_args)
-    cmd.extend(
-        [
-            f"--lua-filter={filter_path}",
-            f"--resource-path={resource_path}",
-            "-H",
-            header_file,
-        ]
-    )
+    args = [f"--resource-path={resource_path}", "-H", header_file]
+    if filter_path:
+        args.insert(0, f"--lua-filter={filter_path}")
+    cmd.extend(args)
     return cmd
 
 

--- a/tools/gitbook_worker/src/gitbook_worker/utils.py
+++ b/tools/gitbook_worker/src/gitbook_worker/utils.py
@@ -132,7 +132,10 @@ def wrap_wide_tables(
     in_code = False
 
     def wrap(table: List[str]) -> List[str]:
-        max_cols = max((l.count("|") - 1) for l in table if l.lstrip().startswith("|"))
+        cols = [l.count("|") - 1 for l in table if l.lstrip().startswith("|")]
+        if not cols:
+            return table
+        max_cols = max(cols)
         if max_cols <= threshold:
             return table
         if not use_raw_latex:
@@ -337,7 +340,7 @@ def _write_pandoc_header(
                     )
             if wrap_tables:
                 logging.info("Wrapping wide tables in landscape environment...")
-                wrap_wide_tables(md_file, threshold=threshold, use_raw_latex=True)
+                wrap_wide_tables(md_file, threshold=threshold, use_raw_latex=False)
                 hf.write("\\usepackage{pdflscape}\n")
                 logging.info("Wide tables wrapped successfully.")
     except Exception as e:


### PR DESCRIPTION
## Summary
- fix wide table wrap logic
- load `pdflscape` via header when wrapping tables
- skip landscape filter if not needed
- support optional filter in Docker/normal pandoc commands

## Testing
- `gitbook-worker file:///workspace/erda-book --branch work --pdf ERDA_Buch_Test --wrap-wide-tables --emoji-color --clone-dir /tmp/gitbook_clone --temp-dir /tmp/gitbook_temp --out-dir /tmp/gitbook_out --force`
- `gitbook-worker file:///workspace/erda-book --branch work --pdf ERDA_Buch_Docker_Test --wrap-wide-tables --emoji-color --use-docker --clone-dir /tmp/gitbook_clone_d --temp-dir /tmp/gitbook_temp_d --out-dir /tmp/gitbook_out_d --force` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_686907f85114832aaedcbdfd0474ba5d