### PR TITLE
Fix HTML table conversion

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/utils.py
+++ b/tools/gitbook_worker/src/gitbook_worker/utils.py
@@ -190,12 +190,12 @@ def wrap_wide_tables(
                 i += 1
             html = "".join(table_lines)
             try:
-                out = run(
+                stdout, _, _ = run(
                     ["pandoc", "-f", "html", "-t", "gfm", "--wrap=none", "-"],
                     capture_output=True,
-                    input=html.encode("utf-8"),
+                    input_text=html,
                 )
-                md_table = [l + "\n" for l in out.stdout.decode("utf-8").splitlines()]
+                md_table = [l + "\n" for l in stdout.splitlines()]
             except Exception:
                 md_table = table_lines
             new_lines.extend(wrap(md_table))

--- a/tools/gitbook_worker/tests/test_header.py
+++ b/tools/gitbook_worker/tests/test_header.py
@@ -28,7 +28,7 @@ def test_write_pandoc_header_wrap_tables(tmp_path, monkeypatch):
     md = tmp_path / "tables.md"
     md.write_text("|A|B|C|D|E|F|G|\n|--|--|--|--|--|--|--|\n|1|2|3|4|5|6|7|\n")
     called = {}
-    def fake_wrap(md_file, threshold):
+    def fake_wrap(md_file, threshold, **kwargs):
         called['md'] = md_file
         called['th'] = threshold
     monkeypatch.setattr('gitbook_worker.utils.wrap_wide_tables', fake_wrap)

--- a/tools/gitbook_worker/tests/test_wide_tables.py
+++ b/tools/gitbook_worker/tests/test_wide_tables.py
@@ -30,3 +30,17 @@ def test_wrap_wide_tables_html(tmp_path):
     text = md.read_text()
     assert text.startswith("::: {.landscape cols=7}\n")
     assert text.strip().endswith(":::")
+
+
+@pytest.mark.skipif(shutil.which("pandoc") is None, reason="pandoc not installed")
+def test_wrap_wide_tables_html_converted(tmp_path):
+    md = tmp_path / "html2.md"
+    md.write_text(
+        "<table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table>"
+    )
+    wrap_wide_tables(str(md), threshold=1)
+    lines = md.read_text().splitlines()
+    assert lines[0] == "::: {.landscape cols=2}"
+    assert "| A   | B   |" in lines
+    assert "| 1   | 2   |" in lines
+    assert lines[-1] == ":::"


### PR DESCRIPTION
## Summary
- correctly unpack `run()` results in `wrap_wide_tables`
- use `stdout` text for Pandoc HTML conversion
- extend wide table tests for Pandoc-generated HTML
- allow extra kwargs in header test helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686949ab60a4832a94daa1b14c545be0