### PR TITLE
Add adjustbox package for wrapped tables

### DIFF
--- a/tools/gitbook_worker/README.md
+++ b/tools/gitbook_worker/README.md
@@ -15,6 +15,8 @@ Wide tables can be automatically rotated into landscape pages with
 via `--table-threshold`. Both pipe tables and HTML `<table>` blocks are
 detected. When this option is enabled, the font size of these tables is reduced
 depending on their column count so that the content fits without overlapping.
+When using this option, ensure the LaTeX packages `pdflscape` and `adjustbox`
+are installed.
 
 ## 1. Upgrade notes
 

--- a/tools/gitbook_worker/src/gitbook_worker/Dockerfile
+++ b/tools/gitbook_worker/src/gitbook_worker/Dockerfile
@@ -9,7 +9,7 @@ RUN wget -O /usr/share/fonts/OpenMoji-color-glyf_colr_0.ttf https://github.com/h
     fc-cache -f -v
 RUN fc-cache -f -v
 
-# Update TeXLive und installiere pdflscape
-RUN tlmgr update --self --all && tlmgr install pdflscape
+# Update TeXLive und installiere pdflscape und adjustbox
+RUN tlmgr update --self --all && tlmgr install pdflscape adjustbox
 
 WORKDIR /data

--- a/tools/gitbook_worker/src/gitbook_worker/utils.py
+++ b/tools/gitbook_worker/src/gitbook_worker/utils.py
@@ -342,6 +342,7 @@ def _write_pandoc_header(
                 logging.info("Wrapping wide tables in landscape environment...")
                 wrap_wide_tables(md_file, threshold=threshold, use_raw_latex=False)
                 hf.write("\\usepackage{pdflscape}\n")
+                hf.write("\\usepackage{adjustbox}\n")
                 logging.info("Wide tables wrapped successfully.")
     except Exception as e:
         logging.error("Failed to write pandoc header tex file: %s", e)

--- a/tools/gitbook_worker/tests/test_header.py
+++ b/tools/gitbook_worker/tests/test_header.py
@@ -46,6 +46,7 @@ def test_write_pandoc_header_wrap_tables(tmp_path, monkeypatch):
     assert called == {'md': str(md), 'th': 5, 'raw': False}
     content = open(header, encoding="utf-8").read()
     assert "\\usepackage{pdflscape}" in content
+    assert "\\usepackage{adjustbox}" in content
     assert "\\IfFontExistsTF{Segoe UI Emoji}" in content
     assert "luaotfload.add_fallback(\"mainfont\", \"Segoe UI Emoji:mode=harf\")" in content
 


### PR DESCRIPTION
## Summary
- update Dockerfile to install adjustbox
- load adjustbox package when wrapping tables
- test adjustbox in pandoc header
- document adjustbox requirement for wide table wrapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686954397610832aba1c567ae30b1b7f