### PR TITLE
Update table wrapping header and Dockerfile

### DIFF
--- a/tools/gitbook_worker/README.md
+++ b/tools/gitbook_worker/README.md
@@ -15,7 +15,7 @@ Wide tables can be automatically rotated into landscape pages with
 via `--table-threshold`. Both pipe tables and HTML `<table>` blocks are
 detected. When this option is enabled, the font size of these tables is reduced
 depending on their column count so that the content fits without overlapping.
-When using this option, ensure the LaTeX packages `pdflscape` and `adjustbox`
+When using this option, ensure the LaTeX packages `pdflscape` and `ltablex`
 are installed.
 
 ## 1. Upgrade notes

--- a/tools/gitbook_worker/src/gitbook_worker/Dockerfile
+++ b/tools/gitbook_worker/src/gitbook_worker/Dockerfile
@@ -9,7 +9,7 @@ RUN wget -O /usr/share/fonts/OpenMoji-color-glyf_colr_0.ttf https://github.com/h
     fc-cache -f -v
 RUN fc-cache -f -v
 
-# Update TeXLive und installiere pdflscape, adjustbox und ltablex
-RUN tlmgr update --self --all && tlmgr install pdflscape adjustbox ltablex tabularx
+# Update TeXLive und installiere pdflscape und ltablex
+RUN tlmgr update --self --all && tlmgr install pdflscape ltablex tabularx
 
 WORKDIR /data

--- a/tools/gitbook_worker/src/gitbook_worker/utils.py
+++ b/tools/gitbook_worker/src/gitbook_worker/utils.py
@@ -342,7 +342,6 @@ def _write_pandoc_header(
                 logging.info("Wrapping wide tables in landscape environment...")
                 wrap_wide_tables(md_file, threshold=threshold, use_raw_latex=False)
                 hf.write("\\usepackage{pdflscape}\n")
-                hf.write("\\usepackage{adjustbox}\n")
                 hf.write("\\usepackage{ltablex}\n")
                 hf.write("\\usepackage{tabularx}\n")
                 hf.write("\\keepXColumns\n")

--- a/tools/gitbook_worker/tests/test_header.py
+++ b/tools/gitbook_worker/tests/test_header.py
@@ -46,7 +46,7 @@ def test_write_pandoc_header_wrap_tables(tmp_path, monkeypatch):
     assert called == {'md': str(md), 'th': 5, 'raw': False}
     content = open(header, encoding="utf-8").read()
     assert "\\usepackage{pdflscape}" in content
-    assert "\\usepackage{adjustbox}" in content
+    assert "\\usepackage{ltablex}" in content
     assert "\\IfFontExistsTF{Segoe UI Emoji}" in content
     assert "luaotfload.add_fallback(\"mainfont\", \"Segoe UI Emoji:mode=harf\")" in content
 


### PR DESCRIPTION
## Summary
- load `pdflscape` and `ltablex` when rotating wide tables
- adjust Dockerfile to install `ltablex`
- document required packages
- update header tests

## Testing
- `pip install -e tools/gitbook_worker`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a8ba5fdd8832aadd67a9e1e04b507