### PR TITLE
Improve pandoc logging and table conversion messages

### DIFF
--- a/tools/gitbook_worker/README.md
+++ b/tools/gitbook_worker/README.md
@@ -9,6 +9,8 @@ pip install .
 You can then call `gitbook-worker` to process a GitBook repository.
 The optional flag `--verbose` prints progress messages to the console. A log
 file `gitbook_worker_<timestamp>.log` is always written to the output directory.
+The log now records the full pandoc command with start and finish times and the
+resulting exit code.
 
 Wide tables can be automatically rotated into landscape pages with
 `--wrap-wide-tables`. The number of columns considered "wide" can be adjusted

--- a/tools/gitbook_worker/src/gitbook_worker/__main__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__main__.py
@@ -335,11 +335,24 @@ def main():
             except Exception as e:
                 logging.error("Failed to write pandoc header tex file: %s", e)
                 sys.exit(1)
+            wide_tables = False
+            if args.wrap_wide_tables:
+                try:
+                    with open(combined_md, encoding="utf-8") as cf:
+                        if "::: {.landscape" in cf.read():
+                            logging.info("Wide tables detected in markdown")
+                            wide_tables = True
+                except Exception as e:
+                    logging.error(
+                        "Failed to inspect markdown for wide tables: %s", e
+                    )
             filter_path = (
                 os.path.join(os.path.dirname(__file__), "landscape.lua")
                 if args.wrap_wide_tables
                 else ""
             )
+            if wide_tables and filter_path:
+                logging.info("Converting tables to ltablex via landscape.lua")
             docker_cmd = build_docker_pandoc_cmd(
                 out_dir,
                 temp_dir,
@@ -406,6 +419,19 @@ def main():
                     logging.error("Failed to write pandoc header tex file: %s", e)
                     sys.exit(1)
                 extra = []
+            wide_tables = False
+            if args.wrap_wide_tables:
+                try:
+                    with open(combined_md, encoding="utf-8") as cf:
+                        if "::: {.landscape" in cf.read():
+                            logging.info("Wide tables detected in markdown")
+                            wide_tables = True
+                except Exception as e:
+                    logging.error(
+                        "Failed to inspect markdown for wide tables: %s", e
+                    )
+            if wide_tables and filter_path:
+                logging.info("Converting tables to ltablex via landscape.lua")
             pandoc_cmd = build_pandoc_cmd(
                 combined_md,
                 pdf_output,

--- a/tools/gitbook_worker/src/gitbook_worker/pandoc_utils.py
+++ b/tools/gitbook_worker/src/gitbook_worker/pandoc_utils.py
@@ -1,4 +1,6 @@
 import os
+import logging
+from datetime import datetime
 from .utils import run
 
 
@@ -93,4 +95,12 @@ def build_pandoc_cmd(
 
 def run_pandoc(cmd: list[str]):
     """Execute pandoc and return (stdout, stderr, exit_code)."""
-    return run(cmd, capture_output=True)
+    start = datetime.now()
+    logging.info("Starting pandoc at %s", start.isoformat())
+    logging.info("Pandoc command: %s", cmd)
+    out, err, code = run(cmd, capture_output=True)
+    end = datetime.now()
+    logging.info(
+        "Pandoc finished at %s with exit code %s", end.isoformat(), code
+    )
+    return out, err, code


### PR DESCRIPTION
## Summary
- log start/end time and exit code when calling pandoc
- report when wide tables are detected and converted via `ltablex`
- document new logging details in README

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a8cadccc0832a886e98ba5da589e4