### PR TITLE
Fix duplicate import

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/source_extract.py
+++ b/tools/gitbook_worker/src/gitbook_worker/source_extract.py
@@ -20,9 +20,6 @@ def extract_multiline_list_items(text: str) -> List[str]:
     return pattern.findall(text)
 
 
-import re
-
-
 def get_language_dependent_header_pattern_for_sources(
     language: str = "de", max_level: int = 6
 ) -> re.Pattern:


### PR DESCRIPTION
## Summary
- remove redundant `re` import in `source_extract.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686a9954cb14832a8d9a25ea780abef9