### PR TITLE
Fix internal links summary file and tests

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/__main__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__main__.py
@@ -164,7 +164,7 @@ def main():
     parser.add_argument(
         "--fix-internal-links",
         action="store_true",
-        help="Proof and repair internal GitBook links using Summary.md and generate a report.",
+        help="Proof and repair internal GitBook links using SUMMARY.md and generate a report.",
     )
     parser.add_argument(
         "--ai-url",
@@ -575,9 +575,9 @@ def main():
     if args.fix_internal_links:
         logging.info("fix-internal-links started")
         try:
-            summary_md = os.path.join(clone_dir, "Summary.md")
+            summary_md = os.path.join(clone_dir, "SUMMARY.md")
             if not os.path.isfile(summary_md):
-                raise FileNotFoundError(f"Summary.md not found at {summary_md}")
+                raise FileNotFoundError(f"SUMMARY.md not found at {summary_md}")
             report = proof_and_repair_internal_references(md_files, summary_md)
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             report_filename = os.path.join(

--- a/tools/gitbook_worker/tests/test_pandoc_utils.py
+++ b/tools/gitbook_worker/tests/test_pandoc_utils.py
@@ -15,7 +15,6 @@ def test_build_docker_pandoc_cmd_includes_filter(tmp_path):
     assert "--lua-filter=/filters/landscape.lua" in cmd
     assert any("/filters" in part for part in cmd)
     assert "latex" in cmd
-    assert "--longtable" in cmd
 
 
 def test_build_pandoc_cmd_includes_filter():
@@ -31,7 +30,6 @@ def test_build_pandoc_cmd_includes_filter():
     assert str(md_file) in cmd
     assert "--lua-filter=filter.lua" in cmd
     assert "latex" in cmd
-    assert "--longtable" in cmd
 
 
 def test_landscape_lua_trailing_newline():

--- a/tools/gitbook_worker/tests/test_wide_tables.py
+++ b/tools/gitbook_worker/tests/test_wide_tables.py
@@ -71,7 +71,6 @@ def test_landscape_longtable(tmp_path):
         str(md),
         "-t",
         "latex",
-        "--longtable",
         "--lua-filter",
         str(filter_path),
         "-H",


### PR DESCRIPTION
## Summary
- use `SUMMARY.md` consistently when fixing internal links
- update tests to remove deprecated `--longtable` expectations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ab2ff6224832aa7ff10aee49760b3