### PR TITLE
Add option to disable longtable output

### DIFF
--- a/tools/gitbook_worker/README.md
+++ b/tools/gitbook_worker/README.md
@@ -131,7 +131,8 @@ gitbook-worker --help
 ### 4. Longtable-Ausgabe verhindern
 
 Erstellen Sie eine Datei `pandoc_header.tex` mit folgenden Befehlen und binden
-Sie zusätzlich den Lua-Filter `no-longtable.lua` ein:
+Sie zusätzlich den Lua-Filter `no-longtable.lua` ein. Alternativ genügt der
+neue Schalter `--disable-longtable`:
 
 ```latex
 % pandoc_header.tex
@@ -168,11 +169,12 @@ pandoc combined.md -o output.pdf \
   -H pandoc_header.tex --lua-filter=no-longtable.lua
 ```
 
-In `gitbook-worker` fügen Sie die Optionen analog hinzu:
+In `gitbook-worker` können Sie die Option `--disable-longtable` verwenden, um
+dieses Verhalten automatisch zu aktivieren. Der Lua-Filter und der Header werden
+intern eingebunden:
 
 ```bash
 gitbook-worker ... \
-  --lua-filter=/path/to/no-longtable.lua \
-  -H /path/to/pandoc_header.tex \
+  --disable-longtable \
   --pdf "out.pdf"
 ```

--- a/tools/gitbook_worker/src/gitbook_worker/__init__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__init__.py
@@ -94,3 +94,10 @@ def validate_metadata(md_files):
 def spellcheck(repo_dir: str):
     """Run codespell to check for common spelling mistakes."""
     return run(["codespell", "-q", "3"], cwd=repo_dir, capture_output=True)
+
+# Compatibility shim so tests can import "gitbook_worker.src.gitbook_worker".
+import types
+if "gitbook_worker.src.gitbook_worker" not in sys.modules:
+    src_pkg = types.ModuleType("gitbook_worker.src")
+    sys.modules["gitbook_worker.src"] = src_pkg
+    sys.modules["gitbook_worker.src.gitbook_worker"] = sys.modules[__name__]

--- a/tools/gitbook_worker/src/gitbook_worker/utils.py
+++ b/tools/gitbook_worker/src/gitbook_worker/utils.py
@@ -303,8 +303,12 @@ def _write_pandoc_header(
     threshold: int,
     md_file: str,
     write_mainfont: bool = True,
+    disable_longtable: bool = False,
 ) -> str:
-    """Create a temporary pandoc header file and optionally wrap wide tables.
+    """Create a temporary pandoc header file.
+
+    Wide tables can be wrapped when ``wrap_tables`` is ``True`` and the
+    ``longtable`` environment can be disabled with ``disable_longtable``.
 
     ``write_mainfont`` controls whether a ``\setmainfont`` command is written
     to the header. This is useful for pandoc ``>= 3.1.12`` where the main font
@@ -346,6 +350,14 @@ def _write_pandoc_header(
                 hf.write("\\usepackage{tabularx}\n")
                 hf.write("\\keepXColumns\n")
                 logging.info("Wide tables wrapped successfully.")
+            if disable_longtable:
+                hf.write("\\let\\oldlongtable\\longtable\n")
+                hf.write("\\let\\oldendlongtable\\endlongtable\n")
+                hf.write("\\renewenvironment{longtable}[1]{%\n")
+                hf.write("  \\begin{tabular}{#1}%\n")
+                hf.write("}{%\n")
+                hf.write("  \\end{tabular}%\n")
+                hf.write("}\n")
     except Exception as e:
         logging.error("Failed to write pandoc header tex file: %s", e)
         raise

--- a/tools/gitbook_worker/tests/test_header.py
+++ b/tools/gitbook_worker/tests/test_header.py
@@ -89,3 +89,21 @@ def test_write_pandoc_header_skip_mainfont(tmp_path):
     assert "\\setsansfont{Sans}" in content
     assert "\\setmonofont{Mono}" in content
     assert "\\setmainfont" not in content
+
+
+def test_write_pandoc_header_disable_longtable(tmp_path):
+    md = tmp_path / "file.md"
+    md.write_text("x")
+    header = _write_pandoc_header(
+        str(tmp_path),
+        "",
+        "Sans",
+        "Mono",
+        "Main",
+        False,
+        6,
+        str(md),
+        disable_longtable=True,
+    )
+    content = open(header, encoding="utf-8").read()
+    assert "\\renewenvironment{longtable}" in content

--- a/tools/gitbook_worker/tests/test_pandoc_utils.py
+++ b/tools/gitbook_worker/tests/test_pandoc_utils.py
@@ -13,7 +13,7 @@ def test_build_docker_pandoc_cmd_includes_filter(tmp_path):
         combined_md=str(tmp_path / "file.md"),
         pdf_output=str(tmp_path / "out.pdf"),
         header_file=str(tmp_path / "header.tex"),
-        filter_path=str(tmp_path / "landscape.lua"),
+        filter_paths=[str(tmp_path / "landscape.lua")],
     )
     assert "--lua-filter=/filters/landscape.lua" in cmd
     assert any("/filters" in part for part in cmd)
@@ -27,7 +27,7 @@ def test_build_pandoc_cmd_includes_filter():
         pdf_output="out.pdf",
         resource_path=".",
         header_file="header.tex",
-        filter_path="filter.lua",
+        filter_paths=["filter.lua"],
         extra_args=None,
     )
     assert str(md_file) in cmd


### PR DESCRIPTION
## Summary
- add `--disable-longtable` argument
- support multiple Lua filters when building pandoc commands
- allow disabling longtable environment in pandoc header
- expose compatibility shim for legacy imports
- document the new option
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ba6cc31cc832ab6aa88e59c566ed1