### PR TITLE
Implement PDF table tweaks

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/utils.py
+++ b/tools/gitbook_worker/src/gitbook_worker/utils.py
@@ -349,6 +349,8 @@ def _write_pandoc_header(
                 hf.write("\\usepackage{ltablex}\n")
                 hf.write("\\usepackage{tabularx}\n")
                 hf.write("\\keepXColumns\n")
+                hf.write("\\renewcommand\\_\\{\\textunderscore\\allowbreak\\}\n")
+                hf.write("\\setlength{\\tabcolsep}{4pt}\n")
                 logging.info("Wide tables wrapped successfully.")
             if disable_longtable:
                 hf.write("\\let\\oldlongtable\\longtable\n")

--- a/tools/gitbook_worker/tests/test_header.py
+++ b/tools/gitbook_worker/tests/test_header.py
@@ -52,6 +52,8 @@ def test_write_pandoc_header_wrap_tables(tmp_path, monkeypatch):
     assert "\\usepackage{ltablex}" in content
     assert "\\IfFontExistsTF{Segoe UI Emoji}" in content
     assert 'luaotfload.add_fallback("mainfont", "Segoe UI Emoji:mode=harf")' in content
+    assert "\\renewcommand\\_\\{\\textunderscore\\allowbreak\\}" in content
+    assert "\\setlength{\\tabcolsep}{4pt}" in content
 
 
 def test_write_pandoc_header_no_emoji(tmp_path):


### PR DESCRIPTION
## Summary
- tune LaTeX header used by gitbook_worker
- ensure underscores can break in tables
- tighten table spacing for wrapped tables
- verify new lines in header through test

## Testing
- `pytest tools/gitbook_worker/tests/test_header.py::test_write_pandoc_header_wrap_tables -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c0e85f650832a92af31ecb5d21ddf