### PR TITLE
Implement char width threshold for wrapping wide tables

### DIFF
--- a/tools/gitbook_worker/src/gitbook_worker/__main__.py
+++ b/tools/gitbook_worker/src/gitbook_worker/__main__.py
@@ -105,6 +105,12 @@ def main():
         help="Number of columns considered wide for --wrap-wide-tables.",
     )
     parser.add_argument(
+        "--table-char-threshold",
+        type=int,
+        default=72,
+        help="Maximum table line width for --wrap-wide-tables.",
+    )
+    parser.add_argument(
         "--main-font",
         type=str,
         default="DejaVu Serif",
@@ -336,6 +342,7 @@ def main():
                     args.wrap_wide_tables,
                     args.table_threshold,
                     combined_md,
+                    args.table_char_threshold,
                     disable_longtable=args.disable_longtable,
                 )
             except Exception as e:
@@ -399,6 +406,7 @@ def main():
                         args.wrap_wide_tables,
                         args.table_threshold,
                         combined_md,
+                        args.table_char_threshold,
                         write_mainfont=False,
                         disable_longtable=args.disable_longtable,
                     )
@@ -427,6 +435,7 @@ def main():
                         args.wrap_wide_tables,
                         args.table_threshold,
                         combined_md,
+                        args.table_char_threshold,
                         disable_longtable=args.disable_longtable,
                     )
                 except Exception as e:

--- a/tools/gitbook_worker/tests/test_header.py
+++ b/tools/gitbook_worker/tests/test_header.py
@@ -30,9 +30,10 @@ def test_write_pandoc_header_wrap_tables(tmp_path, monkeypatch):
     md.write_text("|A|B|C|D|E|F|G|\n|--|--|--|--|--|--|--|\n|1|2|3|4|5|6|7|\n")
     called = {}
 
-    def fake_wrap(md_file, threshold, use_raw_latex=False):
+    def fake_wrap(md_file, threshold, char_threshold=72, use_raw_latex=False):
         called["md"] = md_file
         called["th"] = threshold
+        called["ch"] = char_threshold
         called["raw"] = use_raw_latex
 
     monkeypatch.setattr("gitbook_worker.utils.wrap_wide_tables", fake_wrap)
@@ -46,7 +47,7 @@ def test_write_pandoc_header_wrap_tables(tmp_path, monkeypatch):
         5,
         str(md),
     )
-    assert called == {"md": str(md), "th": 5, "raw": False}
+    assert called == {"md": str(md), "th": 5, "ch": 72, "raw": False}
     content = open(header, encoding="utf-8").read()
     assert "\\usepackage{pdflscape}" in content
     assert "\\usepackage{ltablex}" in content

--- a/tools/gitbook_worker/tests/test_wide_tables.py
+++ b/tools/gitbook_worker/tests/test_wide_tables.py
@@ -26,6 +26,16 @@ def test_wrap_wide_tables_ignores_narrow(tmp_path):
     assert ":::" not in text
 
 
+def test_wrap_wide_tables_long_lines(tmp_path):
+    md = tmp_path / "longline.md"
+    long_text = "A" * 50
+    md.write_text(f"|Col1|Col2|\n|--|--|\n|{long_text}|b|\n")
+    wrap_wide_tables(str(md), threshold=5, char_threshold=20)
+    text = md.read_text()
+    assert text.startswith("::: {.landscape cols=2}\n")
+    assert text.strip().endswith(":::")
+
+
 @pytest.mark.skipif(shutil.which("pandoc") is None, reason="pandoc not installed")
 def test_wrap_wide_tables_html(tmp_path):
     md = tmp_path / "html.md"


### PR DESCRIPTION
## Summary
- extend `wrap_wide_tables` with `char_threshold` and calculate max width
- accept the new parameter in `_write_pandoc_header`
- expose `--table-char-threshold` option on the CLI
- test long-line wrapping and adjust existing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd8275a90832a98382d67b5af164e